### PR TITLE
Fix nonexisting groups errors and replace stage labels with groups

### DIFF
--- a/src/helpers/group/group-helper.js
+++ b/src/helpers/group/group-helper.js
@@ -10,8 +10,18 @@ export async function getRbacGroups() {
 export async function fetchGroupNames(groupRefs) {
   if (groupRefs) {
     return Promise.all(groupRefs.map(async id => {
-      const group = await api.getGroup(id);
-      return group.name;
+      try {
+        const group = await api.getGroup(id);
+        return group.name;
+      } catch (error) {
+        console.log( 'Debug 3', error);
+        if (!(error && error.status === 404)) {
+          throw error;
+        }
+        else {
+          return id;
+        }
+      }
     }));
   }
 }
@@ -22,8 +32,3 @@ export const fetchFilterGroups = (filterValue) =>
     : ''}`)
   .then(({ data }) => data.map(({ uuid, name }) => ({ label: name, value: uuid })));
 
-export async function fetchGroupOption(uuid) {
-  const option = await api.getGroup(uuid);
-  const group = await option;
-  return { label: group ? group.name : uuid, value: uuid };
-}

--- a/src/helpers/group/group-helper.js
+++ b/src/helpers/group/group-helper.js
@@ -14,7 +14,6 @@ export async function fetchGroupNames(groupRefs) {
         const group = await api.getGroup(id);
         return group.name;
       } catch (error) {
-        console.log( 'Debug 3', error);
         if (!(error && error.status === 404)) {
           throw error;
         }

--- a/src/helpers/group/group-helper.js
+++ b/src/helpers/group/group-helper.js
@@ -14,7 +14,7 @@ export async function fetchGroupNames(groupRefs) {
         const group = await api.getGroup(id);
         return group.name;
       } catch (error) {
-        if (!(error && error.status === 404)) {
+        if (error.status !== 404) {
           throw error;
         }
         else {

--- a/src/helpers/workflow/workflow-helper.js
+++ b/src/helpers/workflow/workflow-helper.js
@@ -12,17 +12,7 @@ export async function fetchWorkflowsWithGroups({ limit = 10, offset = 0 }) {
   const wfData = await workflowApi.listWorkflows(limit, offset);
   const workflows = wfData.data;
   return Promise.all(workflows.map(async wf => {
-    let wfWithGroups = [];
-    try {
-      wfWithGroups = await fetchGroupNames(wf.group_refs);
-    }
-    catch (error) {
-      console.log( 'Debug 1', error);
-      if (!(error && error.status === 404)) {
-        throw error;
-      }
-    }
-
+    const wfWithGroups = await fetchGroupNames(wf.group_refs);
     return { ...wf, group_names: wfWithGroups };
   })).then(data => ({
     ...wfData,
@@ -32,17 +22,7 @@ export async function fetchWorkflowsWithGroups({ limit = 10, offset = 0 }) {
 
 export async function fetchWorkflowWithGroups(id) {
   const wfData = await workflowApi.showWorkflow(id);
-  let wfWithGroups = [];
-  try {
-    wfWithGroups = await fetchGroupNames(wfData.group_refs);
-  }
-  catch (error) {
-    console.log( 'Debug 2', error);
-    if (!(error && error.status === 404)) {
-      throw error;
-    }
-  }
-
+  const  wfWithGroups = await fetchGroupNames(wfData.group_refs);
   return { ...wfData, group_names: wfWithGroups };
 }
 

--- a/src/helpers/workflow/workflow-helper.js
+++ b/src/helpers/workflow/workflow-helper.js
@@ -17,7 +17,8 @@ export async function fetchWorkflowsWithGroups({ limit = 10, offset = 0 }) {
       wfWithGroups = await fetchGroupNames(wf.group_refs);
     }
     catch (error) {
-      if (!(error.response && error.response.status === 404)) {
+      console.log( 'Debug 1', error);
+      if (!(error && error.status === 404)) {
         throw error;
       }
     }
@@ -36,7 +37,8 @@ export async function fetchWorkflowWithGroups(id) {
     wfWithGroups = await fetchGroupNames(wfData.group_refs);
   }
   catch (error) {
-    if (!(error.response && error.response.status === 404)) {
+    console.log( 'Debug 2', error);
+    if (!(error && error.status === 404)) {
       throw error;
     }
   }

--- a/src/smart-components/workflow/add-stages/add-stages-wizard.js
+++ b/src/smart-components/workflow/add-stages/add-stages-wizard.js
@@ -24,8 +24,8 @@ const AddWorkflow = ({
   };
 
   const steps = [
-    { name: 'General Information', component: <StageInformation formData={ formData } handleChange={ handleChange } /> },
-    { name: 'Set Groups', component: <SetStages formData={ formData }
+    { name: 'General information', component: <StageInformation formData={ formData } handleChange={ handleChange } /> },
+    { name: 'Set groups', component: <SetStages formData={ formData }
       handleChange={ handleChange } options={ rbacGroups } /> },
     { name: 'Review', component: <SummaryContent formData={ formData }
       options={ rbacGroups } />, nextButtonText: 'Confirm' }

--- a/src/smart-components/workflow/add-stages/add-stages-wizard.js
+++ b/src/smart-components/workflow/add-stages/add-stages-wizard.js
@@ -25,7 +25,7 @@ const AddWorkflow = ({
 
   const steps = [
     { name: 'General Information', component: <StageInformation formData={ formData } handleChange={ handleChange } /> },
-    { name: 'Set Stages', component: <SetStages formData={ formData }
+    { name: 'Set Groups', component: <SetStages formData={ formData }
       handleChange={ handleChange } options={ rbacGroups } /> },
     { name: 'Review', component: <SummaryContent formData={ formData }
       options={ rbacGroups } />, nextButtonText: 'Confirm' }

--- a/src/smart-components/workflow/add-stages/set-stages.js
+++ b/src/smart-components/workflow/add-stages/set-stages.js
@@ -58,7 +58,7 @@ const SetStages = ({ formData, handleChange, options, title }) => {
   const createStageInput = (idx) => (
     <StackItem key={ `Stack_${idx + 1}` }>
       <FormGroup
-        label={ `Stage ${idx + 1}` }
+        label={ `Group ${idx + 1}` }
         fieldId={ `${idx + 1}_stage_label` }
       >
         <Grid gutter="md">
@@ -66,8 +66,8 @@ const SetStages = ({ formData, handleChange, options, title }) => {
             <AsyncSelect
               cacheOptions
               isClearable
-              label={ `${idx + 1} Stage` }
-              aria-label={ `${idx + 1} Stage` }
+              label={ `${idx + 1} Group` }
+              aria-label={ `${idx + 1} Group` }
               onToggle={ onToggle }
               key={ `stage-${idx + 1}` }
               onChange={ (e) => onStageChange(e, idx) }
@@ -93,14 +93,14 @@ const SetStages = ({ formData, handleChange, options, title }) => {
     <Fragment>
       <Stack gutter="md">
         <StackItem>
-          <Title size="md">{ title || 'Set stages' }</Title>
+          <Title size="md">{ title || 'Set groups' }</Title>
         </StackItem>
         <StackItem>
           <Stack gutter="sm">
             { stageValues.map((_stage, idx) => createStageInput(idx)) }
             <StackItem style={ { borderTop: 10 } }>
               <Button id="add-workflow-stage" variant="link" isInline onClick={ addStage }>
-                <PlusIcon/> { `Add ${ stageValues.length > 0 ? 'another' : 'a'} stage` }
+                <PlusIcon/> { `Add ${ stageValues.length > 0 ? 'another' : 'a'} group` }
               </Button>
             </StackItem>
           </Stack>

--- a/src/smart-components/workflow/add-stages/summary-content.js
+++ b/src/smart-components/workflow/add-stages/summary-content.js
@@ -48,7 +48,7 @@ const SummaryContent = ({ formData }) => {
                 <Text key={ stage.value }
                   className="data-table-detail content"
                   component={ TextVariants.p }>
-                  { `Stage ${idx + 1} : ${wfGroups[idx].label}` }
+                  { `Group ${idx + 1} : ${wfGroups[idx].label}` }
                 </Text>) }
             </StackItem>
           </Stack>

--- a/src/smart-components/workflow/edit-workflow-info-modal.js
+++ b/src/smart-components/workflow/edit-workflow-info-modal.js
@@ -37,9 +37,9 @@ const EditWorkflowInfoModal = ({
   const onCancel = () => {
     addNotification({
       variant: 'warning',
-      title: `Edit workflow's stages`,
+      title: `Edit workflow's groups`,
       dismissable: true,
-      description: `Edit workflow's stages was cancelled by the user.`
+      description: `Edit workflow's groups was cancelled by the user.`
     });
     push('/workflows');
   };

--- a/src/smart-components/workflow/edit-workflow-stages-modal.js
+++ b/src/smart-components/workflow/edit-workflow-stages-modal.js
@@ -48,7 +48,7 @@ const EditWorkflowStagesModal = ({
   const onCancel = () => {
     addNotification({
       variant: 'warning',
-      title: `Edit workflow's stages`,
+      title: `Edit workflow's groups`,
       dismissable: true,
       description: `Edit workflow's stages was cancelled by the user.`
     });
@@ -57,7 +57,7 @@ const EditWorkflowStagesModal = ({
 
   return (
     <Modal
-      title={ `Edit workflow's stages` }
+      title={ `Edit workflow's groups` }
       width={ '40%' }
       isOpen
       onClose={ onCancel }>
@@ -74,7 +74,7 @@ const EditWorkflowStagesModal = ({
                 <SetStages className="stages-modal" formData={ formData }
                   handleChange={ handleChange }
                   options={ rbacGroups }
-                  title={ `Add or remove ${formData.name}'s stages` }/>
+                  title={ `Add or remove ${formData.name}'s groups` }/>
               </StackItem>) }
           </FormGroup>
         </StackItem>

--- a/src/smart-components/workflow/workflows.js
+++ b/src/smart-components/workflow/workflows.js
@@ -65,7 +65,7 @@ const Workflows = ({ fetchRbacGroups, fetchWorkflows, isLoading, pagination, his
           history.push(`/workflows/edit-info/${workflow.id}`)
       },
       {
-        title: 'Edit stages',
+        title: 'Edit groups',
         onClick: (_event, _rowId, workflow) =>
           history.push(`/workflows/edit-stages/${workflow.id}`)
       },

--- a/src/test/smart-components/workflow/add-stages/__snapshots__/set-stages.test.js.snap
+++ b/src/test/smart-components/workflow/add-stages/__snapshots__/set-stages.test.js.snap
@@ -75,7 +75,7 @@ exports[`<SetStages /> should render correctly 1`] = `
                               title={null}
                             />,
                             " ",
-                            "Add a stage",
+                            "Add a group",
                           ],
                           "id": "add-workflow-stage",
                           "isInline": true,
@@ -134,7 +134,7 @@ exports[`<SetStages /> should render correctly 1`] = `
                             </svg>
                           </PlusIcon>
                            
-                          Add a stage
+                          Add a group
                         </button>
                       </Button>
                     </ComponentWithOuia>


### PR DESCRIPTION
Replace 'Stage' with 'Group' labels in the Add/edit workflow menu and modals.

https://projects.engineering.redhat.com/browse/SSP-995

Also updated the error handling for the groups that was causing the workflows list to not display.
