### PR TITLE
Handle requests with sub-requests

### DIFF
--- a/src/helpers/request/request-helper.js
+++ b/src/helpers/request/request-helper.js
@@ -11,10 +11,21 @@ export async function fetchRequest(id) {
   return await requestApi.showRequest(id);
 }
 
+export const fetchRequestActions = (id) => {
+  return actionApi.listActionsByRequest(id);
+};
+
 export async function fetchRequestWithActions(id) {
-  const requestData = await requestApi.showRequest(id);
-  const requestActions = await actionApi.listActionsByRequest(id);
-  return { ...requestData, actions: requestActions };
+  let requestData = await requestApi.showRequest(id);
+  const requestActions = await fetchRequestActions(id);
+
+  if (requestData.number_of_children > 0) {
+    const subRequests = await requestApi.listRequestsByRequest(id);
+    const promises = subRequests.data.map(request => fetchRequestWithActions(request.id));
+    const subRequestsWithActions = await Promise.all(promises);
+    requestData = { ...requestData, children: subRequestsWithActions };
+  }
+  return  { ...requestData, actions: requestActions };
 }
 
 export async function createRequestAction (requestId, actionIn) {

--- a/src/smart-components/request/request-detail/request-list.js
+++ b/src/smart-components/request/request-detail/request-list.js
@@ -41,7 +41,7 @@ class RequestList extends Component {
                 key={ item.id }
                 item={ item }
                 idx={ idx }
-                isActive={ idx + 1 === this.props.active_request }
+                isActive={ idx === 0 }
                 isExpanded={ this.isExpanded(`request-${item.id}`) }
                 toggleExpand={ this.toggleExpand }
               />)) }

--- a/src/smart-components/request/request-detail/request-transcript.js
+++ b/src/smart-components/request/request-detail/request-transcript.js
@@ -5,14 +5,13 @@ import RequestList from './request-list';
 
 const RequestTranscript = ({ request }) => (<Fragment>
   <Title size="sm" style={ { paddingLeft: '32px' } }> Request transcript </Title>
-  <RequestList items={ [ request ] }/>
+  <RequestList items={ request.children ? request.children : [ request ] }/>
 </Fragment>);
 
 RequestTranscript.propTypes = {
   request: PropTypes.shape({
     content: PropTypes.object,
-    stages: PropTypes.array,
-    active_stage: PropTypes.string
+    children: PropTypes.array
   }).isRequired
 };
 


### PR DESCRIPTION
Update helper functions to get the subrequests. 
Display the subrequests in the transcript list and apply the actions on subrequests rather than the parent request, when these exist.

 Note: at the moment, all requests have the Accept/Deny button - will modify to only have the actions apply to the oldest non-complete subrequest.

![Screenshot from 2019-12-18 17-48-49](https://user-images.githubusercontent.com/12769982/71130127-34692e80-21bf-11ea-9a11-a65b30198c6f.png)
