### PR TITLE
Display action button in the requests expanded rows only for requests with no subrequests

### DIFF
--- a/src/smart-components/request/expandable-content.js
+++ b/src/smart-components/request/expandable-content.js
@@ -12,8 +12,8 @@ const ExpandedItem = (data) => {
   </TextContent>);
 };
 
-const ExpandableContent = ({ id, content, state, reason }) => {
-  const requestActive = isRequestStateActive(state);
+const ExpandableContent = ({ id, number_of_children, content, state, reason }) => {
+  const requestActive = isRequestStateActive(state) && !number_of_children;
   return (
     <Fragment>
       <Level>
@@ -52,6 +52,7 @@ const ExpandableContent = ({ id, content, state, reason }) => {
 ExpandableContent.propTypes = {
   id: PropTypes.string,
   content: PropTypes.object,
+  number_of_children: PropTypes.string,
   uname: PropTypes.string,
   state: PropTypes.string,
   reason: PropTypes.string

--- a/src/smart-components/request/request-table-helpers.js
+++ b/src/smart-components/request/request-table-helpers.js
@@ -15,11 +15,13 @@ export const createRows = (data, filterValue) =>
     state,
     decision,
     reason,
+    number_of_children,
     content }, key) => ([
     ...acc, {
       id,
       isOpen: false,
       state,
+      number_of_children,
       cells: [ <Fragment key={ id }><Link to={ `/requests/detail/${id}` }>
         <Button variant="link"> { name } </Button></Link></Fragment>, requester_name,
       timeAgo(created_at), timeAgo(updated_at), state, decision ]

--- a/src/smart-components/request/requests.js
+++ b/src/smart-components/request/requests.js
@@ -44,7 +44,8 @@ const Requests = ({ fetchRequests, isLoading, pagination, history }) => {
       postMethod={ fetchData }/> } />
   </Fragment>;
 
-  const areActionsDisabled = (requestData) => requestData && requestData.state ? !isRequestStateActive(requestData.state.title) : true;
+  const areActionsDisabled = (requestData) => requestData &&
+    requestData.state ? !isRequestStateActive(requestData.state.title) && !requestData.numberOfChildren : true;
 
   const actionResolver = (requestData, { rowIndex }) => {
     return (rowIndex === 1 || areActionsDisabled(requestData) ? null :

--- a/src/smart-components/request/requests.js
+++ b/src/smart-components/request/requests.js
@@ -45,7 +45,7 @@ const Requests = ({ fetchRequests, isLoading, pagination, history }) => {
   </Fragment>;
 
   const areActionsDisabled = (requestData) => requestData &&
-    requestData.state ? !isRequestStateActive(requestData.state.title) && !requestData.numberOfChildren : true;
+    requestData.state ? !isRequestStateActive(requestData.state.title) && !requestData.number_of_children : true;
 
   const actionResolver = (requestData, { rowIndex }) => {
     return (rowIndex === 1 || areActionsDisabled(requestData) ? null :


### PR DESCRIPTION
The list of requests will only display the Approve/Deny/Comment action buttons for requests with no sub-requests.
The request detail page displays the Approve/Deny/Comment buttons for all sub-requests not yet complete, or root requests if there are no child requests.