### PR TITLE
Fix for updated_at column, other content in the request list and detail page

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -59,12 +59,39 @@
     width: 300px;
     background: transparent;
   }
-  svg {
-    vertical-align: -0.125em;
-    z-index: 1000;
+  .filter-icons-container {
     position: absolute;
     right: 8px;
-    top: 10px;
-    fill: #72767B
+    top: 8px;
+    svg {
+      z-index: 1000;
+      fill: #72767B;
+    }
+    &:hover {
+      svg.clear-filter {
+        fill: var(--pf-global--Color--100);
+        cursor: pointer;
+      }
+    }
+  }
+}
+
+.top-toolbar {
+  background-color: #FFFFFF;
+  .pf-c-breadcrumb__item {
+    .active{
+      color: var(--pf-c-breadcrumb__item--Color);
+      text-decoration: none;
+      pointer-events: none;
+    }
+  }
+  h2 {
+    margin-bottom: 0 !important;
+  }
+  .top-toolbar-title {
+    min-width: 200px;
+  }
+  .top-toolbar-title-description {
+    word-break: break-word;
   }
 }

--- a/src/presentational-components/shared/table-toolbar-view.js
+++ b/src/presentational-components/shared/table-toolbar-view.js
@@ -5,7 +5,6 @@ import { Table, TableHeader, TableBody } from '@patternfly/react-table';
 import { defaultSettings  } from '../../helpers/shared/pagination';
 import FilterToolbar from '../../presentational-components/shared/filter-toolbar-item';
 import { Section } from '@redhat-cloud-services/frontend-components';
-import { TableToolbar } from '@redhat-cloud-services/frontend-components/components/TableToolbar';
 import { DataListLoader } from './loader-placeholders';
 import AsyncPagination from '../../smart-components/common/async-pagination';
 
@@ -67,7 +66,7 @@ export const TableToolbarView = ({
     : setRows((rows) => setSelected(rows, id));
 
   const renderToolbar = (isLoading) => {
-    return (<TableToolbar>
+    return (<Toolbar className={ `pf-u-pt-lg pf-u-pr-lg pf-u-pl-lg pf-u-pb-lg top-toolbar` }>
       <Level style={ { flex: 1 } }>
         <LevelItem>
           <Toolbar>
@@ -92,7 +91,7 @@ export const TableToolbarView = ({
           </Toolbar>
         </LevelItem>
       </Level>
-    </TableToolbar>);
+    </Toolbar>);
   };
 
   return (
@@ -119,7 +118,6 @@ export const TableToolbarView = ({
 TableToolbarView.propTypes = {
   isSelectable: propTypes.bool,
   createRows: propTypes.func.isRequired,
-  request: propTypes.func.isRequired,
   columns: propTypes.array.isRequired,
   toolbarButtons: propTypes.func,
   fetchData: propTypes.func.isRequired,

--- a/src/presentational-components/shared/top-toolbar.js
+++ b/src/presentational-components/shared/top-toolbar.js
@@ -7,7 +7,7 @@ import ApprovalBreadcrumbs from './breadcrubms';
 import './top-toolbar.scss';
 
 export const TopToolbar = ({ children,  breadcrumbs, paddingBottom }) => (
-  <div className={ `pf-u-pt-lg pf-u-pr-lg pf-u-pl-lg${paddingBottom ? 'pf-u-pb-sm' : ''} top-toolbar` }>
+  <div className={ `pf-u-pt-lg pf-u-pr-lg pf-u-pl-lg ${paddingBottom ? 'pf-u-pb-sm' : ''} top-toolbar` }>
     { breadcrumbs && (<Level className="pf-u-mb-md">
       <ApprovalBreadcrumbs breadcrumbs={ breadcrumbs } />
     </Level>)

--- a/src/smart-components/request/expandable-content.js
+++ b/src/smart-components/request/expandable-content.js
@@ -1,27 +1,44 @@
-import React, { Fragment } from 'react';
+import React, { Fragment, useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import { TextContent, Text, TextVariants, Level, LevelItem, Button } from '@patternfly/react-core';
 import { isRequestStateActive } from '../../helpers/shared/helpers';
+import { fetchRequestContent } from '../../helpers/request/request-helper';
+import { Skeleton, SkeletonSize } from '@redhat-cloud-services/frontend-components';
 
 const ExpandedItem = (data) => {
-  return (<TextContent>
-    <Text className="data-table-detail heading" component={ TextVariants.small }>{ data ? data.title : '' }</Text>
-    <Text className="data-table-detail content"
-      component={ TextVariants.h5 }>{ data ? data.detail : '' }</Text>
-  </TextContent>);
+  return (
+    <TextContent>
+      <Text className="data-table-detail heading" component={ TextVariants.small }>{ data ? data.title : '' }</Text>
+      { data.isLoading ? <div>
+        <Skeleton size={ SkeletonSize.sm } />
+      </div> : <Text className="data-table-detail content"
+        component={ TextVariants.h5 }>{ data ? data.detail : '' }</Text> }
+    </TextContent>
+  );
 };
 
-const ExpandableContent = ({ id, number_of_children, content, state, reason }) => {
+const ExpandableContent = ({ id, number_of_children, state, reason }) => {
   const requestActive = isRequestStateActive(state) && !number_of_children;
+  const [ requestContent, setRequestContent ] = useState([]);
+  const [ isLoading, setIsLoading ] = useState();
+
+  useEffect(() => {
+    fetchRequestContent(id).then((data) => { setRequestContent(data); setIsLoading(false); }).catch(() => setIsLoading(false));
+  }, [ id ]);
+
   return (
     <Fragment>
       <Level>
         <LevelItem>
           <TextContent>
             <Text className="data-table-detail heading" component={ TextVariants.small }>Product</Text>
-            <Text className="data-table-detail content"
-              component={ TextVariants.h5 }>{ content ? content.product : 'Unknown' }</Text>
+            { isLoading ? <div>
+              <Skeleton size={ SkeletonSize.sm } />
+            </div> :
+              <Text className="data-table-detail content"
+                component={ TextVariants.h5 }>{ requestContent ? requestContent.product : 'Unknown' }
+              </Text> }
           </TextContent>
         </LevelItem>
         { requestActive && <LevelItem>
@@ -39,9 +56,9 @@ const ExpandableContent = ({ id, number_of_children, content, state, reason }) =
         }</Level>
       <Level>
         <LevelItem>
-          <ExpandedItem title="Portfolio" detail={ content ? content.portfolio : 'Unknown' }/>
-          <ExpandedItem title="Platform" detail={ content ? content.platform : 'Unknown' }/>
-          <ExpandedItem title="Reason" detail={ reason ? reason : '' }/>
+          <ExpandedItem title="Portfolio" isLoading={ isLoading } detail={ requestContent ? requestContent.portfolio : 'Unknown' }/>
+          <ExpandedItem title="Platform" isLoading={ isLoading }  detail={ requestContent ? requestContent.platform : 'Unknown' }/>
+          <ExpandedItem title="Reason" isLoading={ isLoading }  detail={ reason ? reason : '' }/>
         </LevelItem>
 
       </Level>

--- a/src/smart-components/request/request-detail/request-info-bar.js
+++ b/src/smart-components/request/request-detail/request-info-bar.js
@@ -3,25 +3,18 @@ import PropTypes from 'prop-types';
 import { Text, TextContent, TextVariants } from '@patternfly/react-core';
 
 const RequestInfoBar = ({ request, requestContent }) => {
+  console.log('DEBUG info bar: request, requestContent: ', request, requestContent);
   return (
     <TextContent>
       <Text component={ TextVariants.small }>Product: <br/></Text>
-      <Text>{ requestContent ? requestContent.product : 'Unknown' }</Text>
-      <Text component={ TextVariants.small }>
-              Portfolio:
-        <br/>
-      </Text>
-      <Text>
-        { requestContent ? requestContent.portfolio : '' }
-      </Text>
+      <Text>{ requestContent ? requestContent.product : '' }</Text>
+      <Text component={ TextVariants.small }>Portfolio: <br/></Text>
+      <Text>{ requestContent ? requestContent.portfolio : '' }</Text>
       <Text component={ TextVariants.small }>Platform: <br/></Text>
-      <Text>{ requestContent ? requestContent.platform : '' }</Text>
-      <Text component={ TextVariants.small }>Project: <br/></Text>
-      <Text>{ requestContent ? requestContent.project : '' }</Text>
-      <Text component={ TextVariants.small }>Order Parameters: </Text>
+      <Text>{ requestContent ? requestContent.platform : ' ' }</Text>
       <Text component={ TextVariants.small }>Requester: </Text>
       <Text component={ TextVariants.h6 }>{ request.requester_name }</Text>
-      <Text component={ TextVariants.h6 }>Project: <br/> </Text>
+      <Text component={ TextVariants.h6 }>Order Parameters: <br/> </Text>
       { requestContent.params && Object.keys(requestContent.params).map(param => {
         return ((requestContent.params[param]) &&
                   <Text key={ param } component={ TextVariants.small }>

--- a/src/smart-components/request/request-detail/request-info-bar.js
+++ b/src/smart-components/request/request-detail/request-info-bar.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { Text, TextContent, TextVariants } from '@patternfly/react-core';
 
 const RequestInfoBar = ({ request, requestContent }) => {
-  console.log('DEBUG info bar: request, requestContent: ', request, requestContent);
   return (
     <TextContent>
       <Text component={ TextVariants.small }>Product: <br/></Text>

--- a/src/smart-components/request/request-table-helpers.js
+++ b/src/smart-components/request/request-table-helpers.js
@@ -10,12 +10,14 @@ export const createRows = (data) =>
     name,
     requester_name,
     created_at,
-    updated_at,
+    notified_at,
+    finished_at,
     state,
     decision,
     reason,
     number_of_children,
-    content }, key) => ([
+    content
+  }, key) => ([
     ...acc, {
       id,
       isOpen: false,
@@ -23,14 +25,16 @@ export const createRows = (data) =>
       number_of_children,
       cells: [ <Fragment key={ id }><Link to={ `/requests/detail/${id}` }>
         <Button variant="link"> { name } </Button></Link></Fragment>, requester_name,
-      timeAgo(created_at), timeAgo(updated_at), state, decision ]
+      timeAgo(created_at), finished_at ? timeAgo(finished_at) : timeAgo(notified_at), state, decision ]
     }, {
       parent: key * 2,
       fullWidth: true,
-      cells: [{ title: <ExpandableContent id={ id }
-        content={ content }
-        state={ state }
-        reason={ reason }/> }]
+      cells: [{
+        title: <ExpandableContent id={ id }
+          content={ content }
+          state={ state }
+          reason={ reason }/>
+      }]
     }
   ]), []);
 

--- a/src/smart-components/request/requests.js
+++ b/src/smart-components/request/requests.js
@@ -22,7 +22,7 @@ const columns = [{
 'Requester',
 'Opened',
 'Updated',
-'State',
+'Status',
 'Decision'
 ];
 

--- a/src/smart-components/workflow/workflows.js
+++ b/src/smart-components/workflow/workflows.js
@@ -143,7 +143,7 @@ const Workflows = () => {
 
   const anyWorkflowsSelected = () => selectedWorkflows.length > 0;
 
-  const toolbarButtons = () => <ToolbarGroup>
+  const toolbarButtons = () => <ToolbarGroup className={ `pf-u-pl-lg top-toolbar` }>
     <ToolbarItem>
       <Link id="add-workflow-link" to="/workflows/add-workflow">
         <Button


### PR DESCRIPTION
Updated_at column displays the finished_at if available, otherwise notified_at.

![Screenshot from 2020-01-16 17-21-24](https://user-images.githubusercontent.com/12769982/72568266-bf544c00-3885-11ea-92ae-4aca36628f05.png)


Updated content in the expanded request row:
![Screenshot from 2020-01-16 23-01-55](https://user-images.githubusercontent.com/12769982/72584125-d3fd0800-38b6-11ea-8925-9dcf3867cedf.png)

Updated request detail info bar:

Before:
![Screenshot from 2020-01-15 17-32-53](https://user-images.githubusercontent.com/12769982/72477550-c44dc880-37bd-11ea-91c7-d642ed5d450c.png)

After:
![Screenshot from 2020-01-16 17-29-48](https://user-images.githubusercontent.com/12769982/72568295-d1ce8580-3885-11ea-905c-59dbd5675c90.png)

Updated content in the expanded request row:

![Screenshot from 2020-01-17 09-52-02](https://user-images.githubusercontent.com/12769982/72621491-5addcf00-390f-11ea-8584-9bab62baab01.png)


