### PR TITLE
Requests list - Use created_at as a backup date for the updated_at column

### DIFF
--- a/src/smart-components/request/request-table-helpers.js
+++ b/src/smart-components/request/request-table-helpers.js
@@ -26,7 +26,7 @@ export const createRows = (data) =>
         <Fragment key={ id }><Link to={ `/requests/detail/${id}` }><Button variant="link"> { name } </Button></Link></Fragment>,
         requester_name,
         timeAgo(created_at),
-        finished_at ? timeAgo(finished_at) : timeAgo(notified_at),
+        finished_at ? timeAgo(finished_at) : (notified_at ? timeAgo(notified_at) : timeAgo(created_at)),
         state,
         decision
       ]

--- a/src/test/smart-components/request/request-detail/__snapshots__/request.test.js.snap
+++ b/src/test/smart-components/request/request-detail/__snapshots__/request.test.js.snap
@@ -444,7 +444,7 @@ exports[`<Request /> should render correctly 1`] = `
                                                 zIndex={9999}
                                               >
                                                 <span>
-                                                  5 days ago
+                                                  6 days ago
                                                 </span>
                                                 <Portal
                                                   containerInfo={
@@ -673,7 +673,7 @@ exports[`<Request /> should render correctly 1`] = `
                                                 zIndex={9999}
                                               >
                                                 <span>
-                                                  5 days ago
+                                                  6 days ago
                                                 </span>
                                                 <Portal
                                                   containerInfo={


### PR DESCRIPTION
Use created_at as a backup date for the updated_at column

Before:
![Screenshot from 2020-02-04 16-13-52](https://user-images.githubusercontent.com/12769982/73788829-bb706700-476b-11ea-8422-c1d39795c169.png)

After:

![Screenshot from 2020-02-04 16-21-47](https://user-images.githubusercontent.com/12769982/73788837-bf9c8480-476b-11ea-873e-c8d6653007f7.png)

