### PR TITLE
Request transcript - Use group names for child requests

### DIFF
--- a/src/smart-components/request/request-detail/request.js
+++ b/src/smart-components/request/request-detail/request.js
@@ -84,7 +84,7 @@ class Request extends Component {
           <DataListItemCells
             dataListCells={ [
               <DataListCell key={ item.id }>
-                <span id={ item.id }>{ `${this.props.idx + 1}. ${item.name}` } </span>
+                <span id={ `${item.id}-name` }>{ `${this.props.idx + 1}. ${item.parent_id ? item.group_name : item.name}` } </span>
               </DataListCell>,
               <DataListCell key={ `${item.id}-state` }>
                 <span style={ { textTransform: 'capitalize' } } id={ `${item.id}-state` }>{ `${item.state}` } </span>
@@ -140,6 +140,8 @@ Request.propTypes = {
     id: PropTypes.string,
     name: PropTypes.string,
     state: PropTypes.string,
+    parent_id: PropTypes.string,
+    group_name: PropTypes.string,
     requestActions: PropTypes.shape({
       data: PropTypes.array
     })

--- a/src/smart-components/request/request-detail/request.js
+++ b/src/smart-components/request/request-detail/request.js
@@ -140,8 +140,8 @@ Request.propTypes = {
     id: PropTypes.string,
     name: PropTypes.string,
     state: PropTypes.string,
-    parent_id: PropTypes.string,
-    group_name: PropTypes.string,
+    parent_id: PropTypes.string.isRequired,
+    group_name: PropTypes.string.isRequired,
     requestActions: PropTypes.shape({
       data: PropTypes.array
     })

--- a/src/test/smart-components/request/request-detail/__snapshots__/request.test.js.snap
+++ b/src/test/smart-components/request/request-detail/__snapshots__/request.test.js.snap
@@ -149,7 +149,7 @@ exports[`<Request /> should render correctly 1`] = `
               Array [
                 <DataListCell>
                   <span
-                    id="111"
+                    id="111-name"
                   >
                     NaN. undefined
                      
@@ -194,7 +194,7 @@ exports[`<Request /> should render correctly 1`] = `
                   className="pf-c-data-list__cell"
                 >
                   <span
-                    id="111"
+                    id="111-name"
                   >
                     NaN. undefined
                      

--- a/src/test/smart-components/request/request-detail/request-list.test.js
+++ b/src/test/smart-components/request/request-detail/request-list.test.js
@@ -30,4 +30,17 @@ describe('<RequestList />', () => {
     button.simulate('click');
     expect(wrapper.state()).toEqual({ expanded: [ 'request-foo' ]});
   });
+
+  it('should use the group name for sub-requests', () => {
+    const wrapper = mount(<RequestList { ...initialProps } items={ [{
+      id: '1',
+      parent_id: '100',
+      group_name: 'Group Name',
+      name: 'Name',
+      actions: []
+    }] }/>);
+    const title = wrapper.find('span');
+    expect(title.first().props()).toEqual({ children: [ '1. Group Name', ' ' ], id: '1-name' });
+  });
+
 });


### PR DESCRIPTION
Note - failing build is fixed in #142 

https://projects.engineering.redhat.com/browse/SSP-1205

All subrequests have the same 'name' field as the parent request, that is the name of the service ordered. Using the group_name instead of the name for each subrequest in the request detail page transcript.
![Screenshot from 2020-02-06 16-28-23](https://user-images.githubusercontent.com/12769982/73980344-07531580-48fe-11ea-966b-2867396aa14b.png)
