### PR TITLE
Remove live update schedule from dependabot.

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -3,7 +3,6 @@ update_configs:
   - package_manager: "javascript"
     update_schedule: "weekly"
     directory: "/"
-    update_schedule: "live"
     default_reviewers:
       - "Hyperkid123"
     allowed_updates:


### PR DESCRIPTION
It's driving me crazy!

Dependabot should run weekly not all the time.