### PR TITLE
Request action transcript - use group name for parent requests

### DIFF
--- a/src/smart-components/request/request-detail/request.js
+++ b/src/smart-components/request/request-detail/request.js
@@ -84,7 +84,7 @@ class Request extends Component {
           <DataListItemCells
             dataListCells={ [
               <DataListCell key={ item.id }>
-                <span id={ `${item.id}-name` }>{ `${this.props.idx + 1}. ${item.parent_id ? item.group_name : item.name}` } </span>
+                <span id={ `${item.id}-name` }>{ `${item.group_name ? item.group_name : item.name}` } </span>
               </DataListCell>,
               <DataListCell key={ `${item.id}-state` }>
                 <span style={ { textTransform: 'capitalize' } } id={ `${item.id}-state` }>{ `${item.state}` } </span>
@@ -140,7 +140,6 @@ Request.propTypes = {
     id: PropTypes.string,
     name: PropTypes.string,
     state: PropTypes.string,
-    parent_id: PropTypes.string.isRequired,
     group_name: PropTypes.string.isRequired,
     requestActions: PropTypes.shape({
       data: PropTypes.array

--- a/src/test/smart-components/request/request-detail/__snapshots__/request.test.js.snap
+++ b/src/test/smart-components/request/request-detail/__snapshots__/request.test.js.snap
@@ -152,7 +152,7 @@ exports[`<Request /> should render correctly 1`] = `
                   <span
                     id="111-name"
                   >
-                    NaN. undefined
+                    undefined
                      
                   </span>
                 </DataListCell>,
@@ -197,7 +197,7 @@ exports[`<Request /> should render correctly 1`] = `
                   <span
                     id="111-name"
                   >
-                    NaN. undefined
+                    undefined
                      
                   </span>
                 </div>

--- a/src/test/smart-components/request/request-detail/request-list.test.js
+++ b/src/test/smart-components/request/request-detail/request-list.test.js
@@ -40,7 +40,7 @@ describe('<RequestList />', () => {
       actions: []
     }] }/>);
     const title = wrapper.find('span');
-    expect(title.first().props()).toEqual({ children: [ '1. Group Name', ' ' ], id: '1-name' });
+    expect(title.first().props()).toEqual({ children: [ 'Group Name', ' ' ], id: '1-name' });
   });
 
 });


### PR DESCRIPTION
Fixes https://projects.engineering.redhat.com/browse/SSP-1380

Before:
![Screenshot from 2020-03-30 17-27-24](https://user-images.githubusercontent.com/12769982/77963671-c9de8900-72ab-11ea-891e-50470e86b196.png)

After:
![Screenshot from 2020-03-30 16-38-56](https://user-images.githubusercontent.com/12769982/77960285-03ac9100-72a6-11ea-93c6-25407335f30c.png)

