### PR TITLE
Update closeUrl for the action modal

### DIFF
--- a/src/smart-components/request/request-detail/request-detail.js
+++ b/src/smart-components/request/request-detail/request-detail.js
@@ -12,6 +12,7 @@ import { RequestLoader } from '../../../presentational-components/shared/loader-
 import { TopToolbar, TopToolbarTitle } from '../../../presentational-components/shared/top-toolbar';
 import UserContext from '../../../user-context';
 import { approvalPersona } from '../../../helpers/shared/helpers';
+import { REQUEST_DETAIL_ROUTE } from '../../../utilities/constants';
 
 const initialState = {
   isFetching: true
@@ -72,11 +73,11 @@ const RequestDetail = () => {
   return (
     <Fragment>
       <Route exact path="/requests/detail/:id/add_comment" render={ props =>
-        <ActionModal { ...props } actionType={ 'Add Comment' } closeUrl={ location.url } /> }/>
+        <ActionModal { ...props } actionType={ 'Add Comment' } closeUrl={ `${REQUEST_DETAIL_ROUTE}${id}` }/> }/>
       <Route exact path="/requests/detail/:id/approve" render={ props =>
-        <ActionModal { ...props } actionType={ 'Approve' } closeUrl={ location.url } /> } />
+        <ActionModal { ...props } actionType={ 'Approve' } closeUrl={ `${REQUEST_DETAIL_ROUTE}${id}` } /> } />
       <Route exact path="/requests/detail/:id/deny" render={ props =>
-        <ActionModal { ...props } actionType={ 'Deny' } closeUrl={ location.url } /> } />
+        <ActionModal { ...props } actionType={ 'Deny' } closeUrl={ `${REQUEST_DETAIL_ROUTE}${id}` }  /> } />
       <TopToolbar
         breadcrumbs={ [{ title: 'Request queue', to: '/requests', id: 'requests' }] }
         paddingBottom={ true }

--- a/src/utilities/constants.js
+++ b/src/utilities/constants.js
@@ -1,3 +1,5 @@
 export const APPROVAL_API_BASE = `${process.env.BASE_PATH}/approval/v1.2`;
 export const RBAC_API_BASE = `${process.env.BASE_PATH}/rbac/v1`;
 
+export const REQUEST_DETAIL_ROUTE = `/requests/detail/`;
+


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/SSP-1167

Return to the same page when closing an action modal.

From the detail page:

![Screenshot from 2020-04-07 09-42-15](https://user-images.githubusercontent.com/12769982/78676181-192c4700-78b4-11ea-9091-8014b834e9b6.png)

From the request list:
![Screenshot from 2020-04-07 09-44-21](https://user-images.githubusercontent.com/12769982/78676503-863fdc80-78b4-11ea-86b3-9014c44a1c25.png)



