### PR TITLE
Add request id to the error notifications

### DIFF
--- a/src/helpers/shared/user-login.js
+++ b/src/helpers/shared/user-login.js
@@ -8,7 +8,10 @@ const axiosInstance = axios.create();
 
 const resolveInterceptor = response => response.data || response;
 const errorInterceptor = (error = {}) => {
-  throw { ...error.response };
+  const requestId = error.response?.headers['x-rh-insights-request-id'];
+  throw requestId
+    ? { ...error.response, sentryId: requestId }
+    : { ...error.response };
 };
 
 // check identity before each request. If the token is expired it will log out user


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/SSP-1257

For this PR - using the existing sentryId parameter to display the x-rh-insights-request-id.
This will be changed after the requestId parameter is added to the platform notifications.

![Screenshot from 2020-04-21 15-37-16](https://user-images.githubusercontent.com/12769982/79907436-92b15280-83e7-11ea-9122-7b0922f0b3d9.png)
