### PR TITLE
[Needs UX] Update remove modal

### DIFF
--- a/src/helpers/workflow/workflow-helper.js
+++ b/src/helpers/workflow/workflow-helper.js
@@ -15,9 +15,7 @@ export function fetchWorkflows(filter = '', pagination = defaultSettings, sortBy
   );
 }
 
-export async function fetchWorkflow(id) {
-  return await workflowApi.showWorkflow(id);
-}
+export const fetchWorkflow = (id) => workflowApi.showWorkflow(id);
 
 export function fetchWorkflowByName(name) {
   return fetchWorkflows(name);

--- a/src/presentational-components/shared/loader-placeholders.js
+++ b/src/presentational-components/shared/loader-placeholders.js
@@ -94,7 +94,7 @@ export const AppPlaceholder = () => (
   </Main>
 );
 
-const FormItemLoader = () => <Loader height={ 64 } width='100%' />;
+export const FormItemLoader = () => <Loader height={ 64 } width='100%' />;
 
 export const WorkflowInfoFormLoader = () => (
   <Form>

--- a/src/smart-components/workflow/remove-workflow-modal.js
+++ b/src/smart-components/workflow/remove-workflow-modal.js
@@ -3,8 +3,8 @@ import PropTypes from 'prop-types';
 import { useHistory } from 'react-router-dom';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
-import { FormattedMessage } from 'react-intl';
 import { Modal, Button, Split, SplitItem, Text, TextContent, TextVariants, Spinner } from '@patternfly/react-core';
+import { FormattedMessage, useIntl } from 'react-intl';
 import { WarningTriangleIcon } from '@patternfly/react-icons';
 import { removeWorkflow, removeWorkflows } from '../../redux/actions/workflow-actions';
 import useQuery from '../../utilities/use-query';
@@ -20,6 +20,7 @@ const RemoveWorkflowModal = ({
   const [ submitting, setSubmitting ] = useState(false);
   const { push } = useHistory();
   const [{ workflow: workflowId }] = useQuery([ 'workflow' ]);
+  const intl = useIntl();
 
   if (!workflowId && (!ids || ids.length === 0)) {
     return null;
@@ -44,14 +45,23 @@ const RemoveWorkflowModal = ({
       isOpen
       variant="small"
       width={ '40%' }
-      title={ '' }
+      title={
+        intl.formatMessage(
+          { id: 'remove-workflow-modal-title', defaultMessage: `Delete {count, number} {count, plural,
+            one {Approval process}
+            other {Approval processes}
+          }?` },
+          { count: workflowId !== undefined ? 1 : ids.length }
+        )
+      }
+      isFooterLeftAligned
       onClose={ onCancel }
       actions={ [
-        <Button id="cancel-remove-workflow" key="cancel" variant="secondary" type="button" onClick={ onCancel }>
-          Cancel
-        </Button>,
-        <Button id="submit-remove-workflow" key="submit" variant="primary" type="button" isDisabled={ submitting } onClick={ onSubmit }>
+        <Button id="submit-remove-workflow" key="submit" variant="danger" type="button" isDisabled={ submitting } onClick={ onSubmit }>
           { submitting ? <React.Fragment><Spinner size="sm" /> Removing </React.Fragment> : 'Remove' }
+        </Button>,
+        <Button id="cancel-remove-workflow" key="cancel" variant="link" type="button" isDisabled={ submitting } onClick={ onCancel }>
+          Cancel
         </Button>
       ] }
     >

--- a/src/smart-components/workflow/remove-workflow-modal.js
+++ b/src/smart-components/workflow/remove-workflow-modal.js
@@ -1,32 +1,45 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { useHistory } from 'react-router-dom';
-import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
-import { Modal, Button, Split, SplitItem, Text, TextContent, TextVariants, Spinner } from '@patternfly/react-core';
+import { useDispatch } from 'react-redux';
+import { Modal, Button, Text, TextContent, TextVariants, Spinner, Title } from '@patternfly/react-core';
 import { FormattedMessage, useIntl } from 'react-intl';
-import { WarningTriangleIcon } from '@patternfly/react-icons';
-import { removeWorkflow, removeWorkflows } from '../../redux/actions/workflow-actions';
+import { ExclamationTriangleIcon } from '@patternfly/react-icons';
+import { removeWorkflow, removeWorkflows, fetchWorkflow } from '../../redux/actions/workflow-actions';
 import useQuery from '../../utilities/use-query';
 import routes from '../../constants/routes';
+import useWorkflow from '../../utilities/use-workflows';
+import { FormItemLoader } from '../../presentational-components/shared/loader-placeholders';
 
 const RemoveWorkflowModal = ({
-  ids,
-  removeWorkflow,
-  removeWorkflows,
+  ids = [],
   fetchData,
   setSelectedWorkflows
 }) => {
+  const dispatch = useDispatch();
+  const [ fetchedWorkflow, setFetchedWorkflow ] = useState();
   const [ submitting, setSubmitting ] = useState(false);
   const { push } = useHistory();
   const [{ workflow: workflowId }] = useQuery([ 'workflow' ]);
-  const intl = useIntl();
 
-  if (!workflowId && (!ids || ids.length === 0)) {
+  const finalId = workflowId || ids.length === 1 && ids[0];
+
+  const intl = useIntl();
+  const workflow = useWorkflow(finalId);
+
+  useEffect(() => {
+    if (finalId && !workflow) {
+      dispatch(fetchWorkflow(finalId))
+      .then(({ value }) => setFetchedWorkflow(value))
+      .catch(() => push(routes.workflows.index));
+    }
+  }, []);
+
+  if (!finalId && ids.length === 0) {
     return null;
   }
 
-  const removeWf = () =>(workflowId ? removeWorkflow(workflowId) : removeWorkflows(ids))
+  const removeWf = () =>(finalId ? dispatch(removeWorkflow(finalId)) : dispatch(removeWorkflows(ids)))
   .catch(() => setSubmitting(false))
   .then(() => push(routes.workflows.index))
   .then(() => setSelectedWorkflows([]))
@@ -41,66 +54,70 @@ const RemoveWorkflowModal = ({
 
   return (
     <Modal
-      aria-label="remove-workflow"
       isOpen
       variant="small"
-      width={ '40%' }
-      title={
-        intl.formatMessage(
-          { id: 'remove-workflow-modal-title', defaultMessage: `Delete {count, number} {count, plural,
-            one {Approval process}
-            other {Approval processes}
-          }?` },
-          { count: workflowId !== undefined ? 1 : ids.length }
-        )
+      aria-label={
+        intl.formatMessage({
+          id: 'remove-workflow-modal-title-aria-label',
+          defaultMessage: `Delete {count, plural, one {approval process} other {approval processes}} modal`
+        },
+        { count: finalId ? 1 : ids.length })
       }
-      isFooterLeftAligned
+      width={ '40%' }
+      header={
+        <Title size="2xl" headingLevel="h1">
+          <ExclamationTriangleIcon size="sm" fill="#f0ab00" className="pf-u-mr-sm" />
+          <FormattedMessage
+            id="remove-workflow-modal-title"
+            defaultMessage={ `Delete {count, plural, one {approval process} other {approval processes}}?` }
+            values={ { count: finalId ? 1 : ids.length } }
+          />
+        </Title>
+      }
       onClose={ onCancel }
       actions={ [
         <Button id="submit-remove-workflow" key="submit" variant="danger" type="button" isDisabled={ submitting } onClick={ onSubmit }>
-          { submitting ? <React.Fragment><Spinner size="sm" /> Removing </React.Fragment> : 'Remove' }
+          { submitting
+            ? <React.Fragment><Spinner size="sm" /> <FormattedMessage id="deleting" defaultMessage="Deleting" /> </React.Fragment>
+            : <FormattedMessage id="delete" defaultMessage="Delete" />
+          }
         </Button>,
         <Button id="cancel-remove-workflow" key="cancel" variant="link" type="button" isDisabled={ submitting } onClick={ onCancel }>
-          Cancel
+          <FormattedMessage id="cancel" defaultMessage="Cancel" />
         </Button>
       ] }
     >
-      <Split hasGutter>
-        <SplitItem>
-          <WarningTriangleIcon size="xl" fill="#f0ab00" />
-        </SplitItem>
-        <SplitItem>
-          <TextContent>
-            <Text component={ TextVariants.p }>
-              <FormattedMessage
-                id="remove-workflow-modal"
-                defaultMessage={ `Removing {count, number} {count, plural,
-              one {approval process}
-              other {approval processes}
-            }` }
+      <TextContent>
+        <Text component={ TextVariants.p }>
+          {
+            (finalId && !workflow && !fetchedWorkflow)
+              ? <FormItemLoader/>
+              : <FormattedMessage
+                id="remove-workflow-modal-text-single"
+                defaultMessage={ `{name} will be removed.` }
                 values={ {
-                  count: workflowId ? 1 : ids.length
+                  name: <b>{
+                    finalId
+                      ? fetchedWorkflow && fetchedWorkflow.name || workflow && workflow.name
+                      : (<React.Fragment>
+                        { ids.length }&nbsp;
+                        <FormattedMessage id="approval-processes" defaultMessage="approval processes"/>
+                      </React.Fragment>)
+
+                  }</b>
                 } }
               />
-            </Text>
-          </TextContent>
-        </SplitItem>
-      </Split>
+          }
+        </Text>
+      </TextContent>
     </Modal>
   );
 };
 
 RemoveWorkflowModal.propTypes = {
-  removeWorkflows: PropTypes.func.isRequired,
-  removeWorkflow: PropTypes.func.isRequired,
   fetchData: PropTypes.func.isRequired,
   setSelectedWorkflows: PropTypes.func.isRequired,
   ids: PropTypes.array
 };
 
-const mapDispatchToProps = (dispatch) => bindActionCreators({
-  removeWorkflow,
-  removeWorkflows
-}, dispatch);
-
-export default connect(null, mapDispatchToProps)(RemoveWorkflowModal);
+export default RemoveWorkflowModal;

--- a/src/test/smart-components/request/request-detail/request-detail.test.js
+++ b/src/test/smart-components/request/request-detail/request-detail.test.js
@@ -47,7 +47,7 @@ describe('<RequestDetail />', () => {
     initialState = {
       requestReducer: {
         isRequestDataLoading: true,
-        selectedRequest: { id: 123 },
+        selectedRequest: { id: '123', name: 'Test product', group_name: 'Test group' },
         requestContent: {}
       }
     };

--- a/src/test/smart-components/workflow/workflows.test.js
+++ b/src/test/smart-components/workflow/workflows.test.js
@@ -705,7 +705,7 @@ describe('<Workflows />', () => {
       });
       wrapper.update();
 
-      expect(wrapper.find('ModalBoxBody').find('p').text()).toEqual('Removing 3 approval processes');
+      expect(wrapper.find('ModalBoxBody').find('p').text()).toEqual('3 approval processes will be removed.');
 
       expect(wrapper.find(MemoryRouter).instance().history.location.pathname).toEqual(routes.workflows.remove);
       expect(wrapper.find(MemoryRouter).instance().history.location.search).toEqual('');
@@ -806,7 +806,7 @@ describe('<Workflows />', () => {
       });
       wrapper.update();
 
-      expect(wrapper.find('ModalBoxBody').find('p').text()).toEqual('Removing 1 approval process');
+      expect(wrapper.find('ModalBoxBody').find('p').text()).toEqual('wf1 will be removed.');
       expect(wrapper.find(MemoryRouter).instance().history.location.pathname).toEqual(routes.workflows.remove);
       expect(wrapper.find(MemoryRouter).instance().history.location.search).toEqual('');
 


### PR DESCRIPTION
SSP-1512

**Before**

![image](https://user-images.githubusercontent.com/32869456/81668006-513f2080-9444-11ea-9e23-95ee20ab33ca.png)

**After**

Updated according to new design

Single process

![image](https://user-images.githubusercontent.com/32869456/84378525-9772d580-abe4-11ea-8294-f2285a113039.png)

Multiple processes

![image](https://user-images.githubusercontent.com/32869456/84378543-a194d400-abe4-11ea-831c-6bc964fe16d1.png)

And because users can go directly to the remove modal via URL for single process, there has to be a loading placeholder until the name is loaded.

![image](https://user-images.githubusercontent.com/32869456/84378601-ba9d8500-abe4-11ea-962f-5c48c6ac265b.png)

Buttons are enabled as they are still working fine without the loaded data. But we can disable/hide them too.