### PR TITLE
Fetch workflow only if it's not in the table

### DIFF
--- a/src/smart-components/workflow/edit-workflow-groups-modal.js
+++ b/src/smart-components/workflow/edit-workflow-groups-modal.js
@@ -9,6 +9,7 @@ import { addWorkflow, updateWorkflow, fetchWorkflow } from '../../redux/actions/
 import { WorkflowInfoFormLoader } from '../../presentational-components/shared/loader-placeholders';
 import SetGroups from './add-groups/set-groups';
 import useQuery from '../../utilities/use-query';
+import useWorkflow from '../../utilities/use-workflows';
 
 import '../../App.scss';
 
@@ -23,6 +24,7 @@ const EditWorkflowGroupsModal = ({
 
   const { push } = useHistory();
   const [{ workflow: id }] = useQuery([ 'workflow' ]);
+  const loadedWorkflow = useWorkflow(id);
 
   const handleChange = data => {
     setValues({ ...formData, ...data });
@@ -37,7 +39,11 @@ const EditWorkflowGroupsModal = ({
   };
 
   useEffect(() => {
-    fetchWorkflow(id).then((result) => setValues(initialValues(result.value)));
+    if (!loadedWorkflow) {
+      fetchWorkflow(id).then((result) => setValues(initialValues(result.value)));
+    } else {
+      setValues(initialValues(loadedWorkflow));
+    }
   }, []);
 
   const onSave = () => {

--- a/src/smart-components/workflow/edit-workflow-info-modal.js
+++ b/src/smart-components/workflow/edit-workflow-info-modal.js
@@ -10,6 +10,7 @@ import { WorkflowInfoFormLoader } from '../../presentational-components/shared/l
 import WorkflowInfoForm from './add-groups/workflow-information';
 import WorkflowSequenceForm from './add-groups/workflow-sequence';
 import useQuery from '../../utilities/use-query';
+import useWorkflow from '../../utilities/use-workflows';
 
 import '../../App.scss';
 
@@ -28,11 +29,16 @@ const EditWorkflowInfoModal = ({
 
   const { push } = useHistory();
   const [{ workflow: id }] = useQuery([ 'workflow' ]);
+  const loadedWorkflow = useWorkflow(id);
 
   const handleChange = data => setFormData({ ...formData, ...data });
 
   useEffect(() => {
-    fetchWorkflow(id).then((data) => { setFormData({ ...formData, ...data.value }); setInitialValue({ ...data.value });});
+    if (!loadedWorkflow) {
+      fetchWorkflow(id).then((data) => { setFormData({ ...formData, ...data.value }); setInitialValue({ ...data.value });});
+    } else {
+      setFormData({ ...formData, ...loadedWorkflow });
+    }
   }, []);
 
   const onSave = () => {
@@ -58,6 +64,8 @@ const EditWorkflowInfoModal = ({
     push('/workflows');
   };
 
+  const name = loadedWorkflow ? loadedWorkflow.name : workflow && workflow.name;
+
   return (
     <Modal
       title={ editType === 'sequence' ? 'Edit sequence' : 'Edit information' }
@@ -72,13 +80,13 @@ const EditWorkflowInfoModal = ({
               <WorkflowInfoForm formData={ formData } initialValue={ initialValue }
                 handleChange={ handleChange }
                 setIsValid={ setIsValid }
-                title={ `Make any changes to approval process ${workflow.name}` }/> :
+                title={ `Make any changes to approval process ${name}` }/> :
               <WorkflowSequenceForm formData={ formData }
                 initialValue={ initialValue }
                 handleChange={ handleChange }
                 isValid={ isValid }
                 setIsValid={ setIsValid }
-                title={ `Set the sequence for the approval process ${workflow.name}` }/>
+                title={ `Set the sequence for the approval process ${name}` }/>
             ) }
           </FormGroup>
         </StackItem>

--- a/src/test/smart-components/workflow/add-groups/edit-workflow-info-modal.test.js
+++ b/src/test/smart-components/workflow/add-groups/edit-workflow-info-modal.test.js
@@ -14,6 +14,7 @@ import { APPROVAL_API_BASE } from '../../../../utilities/constants';
 import { WorkflowInfoFormLoader } from '../../../../presentational-components/shared/loader-placeholders';
 
 import routes from '../../../../constants/routes';
+import { Title } from '@patternfly/react-core';
 
 const ComponentWrapper = ({ store, children }) => (
   <Provider store={ store }>
@@ -60,6 +61,31 @@ describe('<EditWorkflowInfoModal />', () => {
     wrapper.update();
 
     expect(wrapper.find(WorkflowInfoForm)).toHaveLength(1);
+    done();
+  });
+
+  it('should render WorkflowInfoForm when workflow is in table', async done => {
+    const store = mockStore({
+      workflowReducer: {
+        workflows: {
+          data: [
+            { id: '123', name: 'pokus' }
+          ]
+        }
+      }
+    });
+    let wrapper;
+
+    await act(async () => {
+      wrapper = mount(
+        <ComponentWrapper store={ store }>
+          <Route path="/foo" render={ props => <EditWorkflowInfoModal { ...props } { ...initialProps } /> }/>
+        </ComponentWrapper>
+      );
+    });
+    wrapper.update();
+
+    expect(wrapper.find(Title).last().text().includes('pokus')).toEqual(true);
     done();
   });
 

--- a/src/test/smart-components/workflow/edit-workflow-stages-modal.test.js
+++ b/src/test/smart-components/workflow/edit-workflow-stages-modal.test.js
@@ -12,6 +12,7 @@ import { APPROVAL_API_BASE, RBAC_API_BASE } from '../../../utilities/constants';
 import EditWorkflowGroupsModal from '../../../smart-components/workflow/edit-workflow-groups-modal';
 import { WorkflowInfoFormLoader } from '../../../presentational-components/shared/loader-placeholders';
 import SetGroups from '../../../smart-components/workflow/add-groups/set-groups';
+import { Title } from '@patternfly/react-core';
 
 describe('<EditWorkflowGroupsModal />', () => {
   let initialProps;
@@ -105,6 +106,38 @@ describe('<EditWorkflowGroupsModal />', () => {
     });
 
     wrapper.update();
+    expect(wrapper.find(SetGroups)).toHaveLength(1);
+    done();
+  });
+
+  it('should mount with workflow in the table', async done => {
+    const store = mockStore({ workflowReducer: {
+      workflows: {
+        data: [
+          { id: '123', name: 'pokus', group_refs: []}
+        ]
+      }
+    },
+    groupReducer: { groups: [{  value: '123', label: 'Group 1' }]}});
+    let wrapper;
+
+    apiClientMock.get(`${RBAC_API_BASE}/groups/?role_names=%22%2CApproval%20Administrator%2CApproval%20Approver%2C%22`,
+      mockOnce({ body: { data: []}}));
+
+    await act(async() => {
+      wrapper = mount(
+        <ComponentWrapper initialEntries={ [ '/foo?workflow=123' ] } store={ store } >
+          <Route path="/foo" render={ props => <EditWorkflowGroupsModal
+            { ...props }
+            { ...initialProps }
+          /> }/>
+        </ComponentWrapper>
+      );
+
+    });
+
+    wrapper.update();
+    expect(wrapper.find(Title).last().text().includes('pokus')).toEqual(true);
     expect(wrapper.find(SetGroups)).toHaveLength(1);
     done();
   });

--- a/src/utilities/use-workflows.js
+++ b/src/utilities/use-workflows.js
@@ -1,0 +1,9 @@
+import { shallowEqual, useSelector } from 'react-redux';
+
+const useWorkflow = (id) => {
+  const { workflows } = useSelector(({ workflowReducer: { workflows }}) => ({ workflows }), shallowEqual);
+
+  return workflows && workflows.data && workflows.data.find((wf) => wf.id === id);
+};
+
+export default useWorkflow;


### PR DESCRIPTION
SSP-1521

When the workflow is in the table - it's used instead of fetching.

**Before**

![fetchingbefore](https://user-images.githubusercontent.com/32869456/82209691-fb6bec00-990d-11ea-8f72-9eb20c6de66c.gif)

**After**

![fetchingafter](https://user-images.githubusercontent.com/32869456/82209697-fe66dc80-990d-11ea-96a2-58a14e1e68c5.gif)

@Hyperkid123 