### PR TITLE
Fixed ambiguous request routing.

### DIFF
--- a/src/Routes.js
+++ b/src/Routes.js
@@ -4,10 +4,12 @@ import ProtectedRoute from './routing/protected-route';
 import CommonApiError from './smart-components/error-pages/common-api-error';
 
 const Requests = lazy(() => import(/* webpackChunkName: "requests" */ './smart-components/request/requests'));
+const RequestDetail = lazy(() => import(/* webpackChunkName: "request-detail" */ './smart-components/request/request-detail/request-detail'));
 const Workflows = lazy(() => import(/* webpackChunkName: "workflows" */ './smart-components/workflow/workflows'));
 
 const paths = {
   requests: '/requests',
+  request: '/request',
   workflows: '/workflows'
 };
 const errorPaths = [ '/400', '/401', '/404' ];
@@ -16,6 +18,7 @@ export const Routes = () => (
   <Switch>
     <ProtectedRoute path={ paths.workflows } component={ Workflows }/>
     <Route path={ paths.requests } component={ Requests }/>
+    <Route path={ paths.request } component={ RequestDetail }/>
     <Route path={ errorPaths } component={ CommonApiError } />
     <Route>
       <Redirect to={ paths.requests } />

--- a/src/constants/routes.js
+++ b/src/constants/routes.js
@@ -5,6 +5,12 @@ const routes = {
     approve: '/requests/approve',
     deny: '/requests/deny'
   },
+  request: {
+    index: '/request',
+    addComment: '/request/add-comment',
+    approve: '/request/approve',
+    deny: '/request/deny'
+  },
   workflows: {
     index: '/workflows',
     add: '/workflows/add-workflow',

--- a/src/smart-components/request/expandable-content.js
+++ b/src/smart-components/request/expandable-content.js
@@ -6,6 +6,7 @@ import { TextContent, Text, TextVariants, Level, LevelItem, Button, Bullseye, Sp
 import { isApprovalApprover, isRequestStateActive } from '../../helpers/shared/helpers';
 import { fetchRequestContent } from '../../helpers/request/request-helper';
 import UserContext from '../../user-context';
+import routes from '../../constants/routes';
 
 export const ExpandedItem = ({ title = '', detail = '' }) => (
   <TextContent>
@@ -47,12 +48,12 @@ const ExpandableContent = ({ id, number_of_children, state, reason }) => {
           <ExpandedItem title="Product" detail={ requestContent ? requestContent.product : 'Unknown' } />
         </LevelItem>
         { requestActive && isApprovalApprover(userPersona) && <LevelItem>
-          <Link to={ `/requests/approve/${id}` }  className="pf-u-mr-md">
+          <Link to={ { pathname: routes.requests.approve, search: `request=${id}` } }  className="pf-u-mr-md">
             <Button variant="primary" aria-label="Approve Request" isDisabled={ !requestActive }>
               Approve
             </Button>
           </Link>
-          <Link to={ `/requests/deny/${id}` }>
+          <Link to={ { pathname: routes.requests.deny, search: `request=${id}` } }>
             <Button variant="danger" aria-label="Deny Request">
               Deny
             </Button>

--- a/src/smart-components/request/request-detail/request-detail.js
+++ b/src/smart-components/request/request-detail/request-detail.js
@@ -1,5 +1,5 @@
 import React, { Fragment, useContext, useEffect, useReducer } from 'react';
-import { Route, useLocation } from 'react-router-dom';
+import { Route, useLocation, Switch } from 'react-router-dom';
 import { useSelector, useDispatch } from 'react-redux';
 import { Grid, GridItem } from '@patternfly/react-core';
 import { Section } from '@redhat-cloud-services/frontend-components/components/Section';
@@ -72,12 +72,15 @@ const RequestDetail = () => {
 
   return (
     <Fragment>
-      <Route exact path={ routes.requests.addComment } render={ props =>
-        <ActionModal { ...props } actionType={ 'Add Comment' } closeUrl={ { pathname: routes.requests.index, search } }/> }/>
-      <Route exact path={ routes.requests.approve } render={ props =>
-        <ActionModal { ...props } actionType={ 'Approve' } closeUrl={ { pathname: routes.requests.index, search } } /> } />
-      <Route exact path={ routes.requests.deny } render={ props =>
-        <ActionModal { ...props } actionType={ 'Deny' } closeUrl={ { pathname: routes.requests.index, search } }  /> } />
+      <Switch>
+        <Route exact path={ routes.request.addComment }>
+          <ActionModal actionType={ 'Add Comment' } closeUrl={ { pathname: routes.request.index, search } }/>
+        </Route>
+        <Route exact path={ routes.request.approve } render={ props =>
+          <ActionModal { ...props } actionType={ 'Approve' } closeUrl={ { pathname: routes.request.index, search } } /> } />
+        <Route exact path={ routes.request.deny } render={ props =>
+          <ActionModal { ...props } actionType={ 'Deny' } closeUrl={ { pathname: routes.request.index, search } }  /> } />
+      </Switch>
       <TopToolbar
         breadcrumbs={ [
           { title: 'Request queue', to: routes.requests.index, id: 'requests' },

--- a/src/smart-components/request/request-detail/request.js
+++ b/src/smart-components/request/request-detail/request.js
@@ -58,7 +58,7 @@ export const Request = ({ item, isExpanded, toggleExpand }) => {
             <Link
               id={ `request-${request.id}-request-comment` }
               to={ {
-                pathname: routes.requests.addComment,
+                pathname: routes.request.addComment,
                 search: `?request=${request.id}`
               } }
               className="pf-c-dropdown__menu-item"
@@ -101,12 +101,12 @@ export const Request = ({ item, isExpanded, toggleExpand }) => {
                 <LevelItem>
                   { (isRequestStateActive(item.state) && checkCapability(item, 'approve')) &&
                     <div>
-                      <Link id={ `approve-${item.id}` } to={ { pathname: routes.requests.approve, search: `?request=${item.id}` } }>
+                      <Link id={ `approve-${item.id}` } to={ { pathname: routes.request.approve, search: `?request=${item.id}` } }>
                         <Button variant="link" aria-label="Approve Request">
                           Approve
                         </Button>
                       </Link>
-                      <Link id={ `deny-${item.id}` } to={ { pathname: routes.requests.deny, search: `?request=${item.id}` } }>
+                      <Link id={ `deny-${item.id}` } to={ { pathname: routes.request.deny, search: `?request=${item.id}` } }>
                         <Button variant="link" className="destructive-color" aria-label="Deny Request">
                           Deny
                         </Button>

--- a/src/smart-components/request/request-table-helpers.js
+++ b/src/smart-components/request/request-table-helpers.js
@@ -22,7 +22,7 @@ export const createRows = (data) =>
       state,
       number_of_children,
       cells: [
-        <Fragment key={ id }><Link to={ { pathname: routes.requests.index, search: `?request=${id}` } }>{ name }</Link></Fragment>,
+        <Fragment key={ id }><Link to={ { pathname: routes.request.index, search: `?request=${id}` } }>{ name }</Link></Fragment>,
         requester_name,
         timeAgo(created_at),
         finished_at ? timeAgo(finished_at) : (notified_at ? timeAgo(notified_at) : timeAgo(created_at)),

--- a/src/smart-components/request/requests.js
+++ b/src/smart-components/request/requests.js
@@ -8,7 +8,6 @@ import { fetchRequests, expandRequest, sortRequests } from '../../redux/actions/
 import ActionModal from './action-modal';
 import { createRows } from './request-table-helpers';
 import { TableToolbarView } from '../../presentational-components/shared/table-toolbar-view';
-import RequestDetail from './request-detail/request-detail';
 import { isApprovalAdmin, isApprovalApprover, isRequestStateActive } from '../../helpers/shared/helpers';
 import { TopToolbar, TopToolbarTitle } from '../../presentational-components/shared/top-toolbar';
 import AppTabs from '../../smart-components/app-tabs/app-tabs';
@@ -18,7 +17,6 @@ import { SearchIcon } from '@patternfly/react-icons/dist/js/index';
 import TableEmptyState from '../../presentational-components/shared/table-empty-state';
 import UserContext from '../../user-context';
 import routesLinks from '../../constants/routes';
-import useQuery from '../../utilities/use-query';
 
 const columns = [{
   title: 'Name',
@@ -75,7 +73,6 @@ const Requests = () => {
 
   const dispatch = useDispatch();
   const history = useHistory();
-  const [{ request }] = useQuery([ 'request' ]);
 
   useEffect(() => {
     dispatch(
@@ -145,53 +142,49 @@ const Requests = () => {
     .catch(() => stateDispatch({ type: 'setFetching', payload: false }));
   };
 
-  const renderRequestsList = () => {
-    return (
-      <Fragment>
-        <TopToolbar>
-          <TopToolbarTitle title="Approval"/>
-          { isApprovalAdmin(userPersona) && <AppTabs tabItems={ tabItems } /> }
-        </TopToolbar>
-        <TableToolbarView
-          sortBy={ sortBy }
-          onSort={ onSort }
-          data={ data }
-          createRows={ createRows }
-          columns={ columns }
-          fetchData={ handlePagination }
-          routes={ routes }
-          actionResolver={ actionResolver }
-          titlePlural="requests"
-          titleSingular="request"
-          pagination={ meta }
-          handlePagination={ handlePagination }
-          filterValue={ filterValue }
-          onFilterChange={ handleFilterChange }
-          isLoading={ isFetching || isFiltering }
-          onCollapse={ onCollapse }
-          renderEmptyState={ () => (
-            <TableEmptyState
-              title={ filterValue === '' ? 'No requests' : 'No results found' }
-              Icon={ SearchIcon }
-              PrimaryAction={ () =>
-                filterValue !== '' ? (
-                  <Button onClick={ () => handleFilterChange('') } variant="link">
+  return (
+    <Fragment>
+      <TopToolbar>
+        <TopToolbarTitle title="Approval"/>
+        { isApprovalAdmin(userPersona) && <AppTabs tabItems={ tabItems } /> }
+      </TopToolbar>
+      <TableToolbarView
+        sortBy={ sortBy }
+        onSort={ onSort }
+        data={ data }
+        createRows={ createRows }
+        columns={ columns }
+        fetchData={ handlePagination }
+        routes={ routes }
+        actionResolver={ actionResolver }
+        titlePlural="requests"
+        titleSingular="request"
+        pagination={ meta }
+        handlePagination={ handlePagination }
+        filterValue={ filterValue }
+        onFilterChange={ handleFilterChange }
+        isLoading={ isFetching || isFiltering }
+        onCollapse={ onCollapse }
+        renderEmptyState={ () => (
+          <TableEmptyState
+            title={ filterValue === '' ? 'No requests' : 'No results found' }
+            Icon={ SearchIcon }
+            PrimaryAction={ () =>
+              filterValue !== '' ? (
+                <Button onClick={ () => handleFilterChange('') } variant="link">
                             Clear all filters
-                  </Button>
-                ) : null
-              }
-              description={
-                filterValue === ''
-                  ? ''
-                  : 'No results match the filter criteria. Remove all filters or clear all filters to show results.'
-              }
-            />
-          ) }
-        />
-      </Fragment>);
-  };
-
-  return request ? <RequestDetail /> : renderRequestsList();
+                </Button>
+              ) : null
+            }
+            description={
+              filterValue === ''
+                ? ''
+                : 'No results match the filter criteria. Remove all filters or clear all filters to show results.'
+            }
+          />
+        ) }
+      />
+    </Fragment>);
 };
 
 Requests.propTypes = {

--- a/src/test/smart-components/request/request-detail/request.test.js
+++ b/src/test/smart-components/request/request-detail/request.test.js
@@ -112,10 +112,10 @@ describe('<Request />', () => {
     wrapper.find('Link#approve-111').simulate('click', { button: 0 });
     wrapper.update();
     const history = wrapper.find(MemoryRouter).instance().history;
-    expect(history.location.pathname).toEqual(routes.requests.approve);
+    expect(history.location.pathname).toEqual(routes.request.approve);
     expect(history.location.search).toEqual('?request=111');
     wrapper.find('Link#deny-111').simulate('click', { button: 0 });
-    expect(history.location.pathname).toEqual(routes.requests.deny);
+    expect(history.location.pathname).toEqual(routes.request.deny);
     expect(history.location.search).toEqual('?request=111');
   });
 


### PR DESCRIPTION
jira: https://projects.engineering.redhat.com/browse/SSP-1541

### Issue
- the request detail and requests components were sharing routes (both hanged on '/requests')
- components were not chosen based on the route, but based on the query
- this caused that the detail component was eating the list component

### Changes
- add a separate route for request detail `/request`
- request detail and list components are now independent
- fixed old link pathname for request approve/deny modals in the expandable content

Note: ~~It's possible that the same thing is happening on the workflows. Checking that now.~~ Workflows do not have nested routing