### PR TITLE
Small UX fixes - dropdown items use buttons, black delete button

### DIFF
--- a/src/smart-components/request/requests.js
+++ b/src/smart-components/request/requests.js
@@ -146,6 +146,7 @@ const Requests = () => {
       [
         {
           title: 'Comment',
+          component: 'button',
           onClick: () => history.push({
             pathname: routesLinks.requests.addComment,
             search: `?request=${requestData.id}`

--- a/src/smart-components/workflow/workflows.js
+++ b/src/smart-components/workflow/workflows.js
@@ -139,21 +139,25 @@ const Workflows = () => {
     : [
       {
         title: 'Edit info',
+        component: 'button',
         onClick: (_event, _rowId, workflow) =>
           history.push({ pathname: routesLinks.workflows.editInfo, search: `?workflow=${workflow.id}` })
       },
       {
         title: 'Edit groups',
+        component: 'button',
         onClick: (_event, _rowId, workflow) =>
           history.push({ pathname: routesLinks.workflows.editGroups, search: `?workflow=${workflow.id}` })
       },
       {
         title: 'Edit sequence',
+        component: 'button',
         onClick: (_event, _rowId, workflow) =>
           history.push({ pathname: routesLinks.workflows.editSequence, search: `?workflow=${workflow.id}` })
       },
       {
         title: 'Delete',
+        component: 'button',
         style: { color: 'var(--pf-global--danger-color--100)'	},
         onClick: (_event, _rowId, workflow) =>
           history.push({ pathname: routesLinks.workflows.remove, search: `?workflow=${workflow.id}` })

--- a/src/smart-components/workflow/workflows.js
+++ b/src/smart-components/workflow/workflows.js
@@ -158,7 +158,6 @@ const Workflows = () => {
       {
         title: 'Delete',
         component: 'button',
-        style: { color: 'var(--pf-global--danger-color--100)'	},
         onClick: (_event, _rowId, workflow) =>
           history.push({ pathname: routesLinks.workflows.remove, search: `?workflow=${workflow.id}` })
       }

--- a/src/test/smart-components/workflow/workflows.test.js
+++ b/src/test/smart-components/workflow/workflows.test.js
@@ -126,7 +126,7 @@ describe('<Workflows />', () => {
      */
     wrapper.find('button.pf-c-dropdown__toggle.pf-m-plain').last().simulate('click');
     await act(async() => {
-      wrapper.find('div.pf-c-dropdown__menu-item').first().simulate('click');
+      wrapper.find('button.pf-c-dropdown__menu-item').first().simulate('click');
     });
 
     wrapper.update();
@@ -169,7 +169,7 @@ describe('<Workflows />', () => {
      */
     wrapper.find('button.pf-c-dropdown__toggle.pf-m-plain').last().simulate('click');
     await act(async() => {
-      wrapper.find('div.pf-c-dropdown__menu-item').at(1).simulate('click');
+      wrapper.find('button.pf-c-dropdown__menu-item').at(1).simulate('click');
     });
 
     wrapper.update();
@@ -212,7 +212,7 @@ describe('<Workflows />', () => {
      */
     wrapper.find('button.pf-c-dropdown__toggle.pf-m-plain').last().simulate('click');
     await act(async() => {
-      wrapper.find('div.pf-c-dropdown__menu-item').at(2).simulate('click');
+      wrapper.find('button.pf-c-dropdown__menu-item').at(2).simulate('click');
     });
 
     wrapper.update();
@@ -255,7 +255,7 @@ describe('<Workflows />', () => {
      */
     wrapper.find('button.pf-c-dropdown__toggle.pf-m-plain').last().simulate('click');
     await act(async() => {
-      wrapper.find('div.pf-c-dropdown__menu-item').at(3).simulate('click');
+      wrapper.find('button.pf-c-dropdown__menu-item').at(3).simulate('click');
     });
 
     wrapper.update();


### PR DESCRIPTION
Two small UX/UI changes:

1) Dropdown items are buttons - when hovering, there is the click cursor variant

2) Delete button is black now (as in other platform apps)

Before

![before](https://user-images.githubusercontent.com/32869456/82568459-23ae5180-9b7f-11ea-95e2-b1fabff23378.gif)

After

![uxsmall](https://user-images.githubusercontent.com/32869456/82568338-f1045900-9b7e-11ea-8725-600af0e2a54d.gif)

What do you think, @sbuenafe-rh ?
