### PR TITLE
[WIP]Only display request queue for approvers

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -13,7 +13,7 @@ import '@redhat-cloud-services/frontend-components-notifications/index.css';
 import '@redhat-cloud-services/frontend-components/index.css';
 import { getRbacRoleApi } from './helpers/shared/user-login';
 import UserContext from './user-context';
-import { approvalPersona } from './helpers/shared/helpers';
+import { approvalRoles } from './helpers/shared/helpers';
 
 import './App.scss';
 
@@ -29,7 +29,7 @@ if (pathName[0] === 'beta') {
 
 const App = () => {
   const [ auth, setAuth ] = useState(false);
-  const [ userPersona, setUserPersona ] = useState([]);
+  const [ userRoles, setUserRoles ] = useState({});
 
   useEffect(() => {
     insights.chrome.init();
@@ -39,7 +39,7 @@ const App = () => {
       .then(() =>
         getRbacRoleApi()
         .listRoles(defaultSettings.limit, 0, 'Approval ', 'principal')
-        .then((result) => setUserPersona(approvalPersona(result?.data)))
+        .then((result) => setUserRoles(approvalRoles(result?.data)))
       )
     ]).then(() => setAuth(true));
 
@@ -54,7 +54,7 @@ const App = () => {
     <BrowserRouter basename={ `${release}${pathName[0]}/${pathName[1]}/${pathName[2]}` }>
       <Suspense fallback={ <AppPlaceholder /> }>
         <IntlProvider locale="en">
-          <UserContext.Provider value={ { userPersona } }>
+          <UserContext.Provider value={ { userRoles } }>
             <React.Fragment>
               <NotificationsPortal />
               <Main className="pf-u-p-0 pf-u-ml-0">

--- a/src/Routes.js
+++ b/src/Routes.js
@@ -1,25 +1,40 @@
 import { Route, Switch, Redirect } from 'react-router-dom';
-import React, { lazy } from 'react';
+import React, { lazy, useContext } from 'react';
 import ProtectedRoute from './routing/protected-route';
 import CommonApiError from './smart-components/error-pages/common-api-error';
 import paths from './constants/routes';
+import UserContext from './user-context';
+import { isApprovalAdmin, isApprovalApprover } from './helpers/shared/helpers';
+import RequestsRoute from './routing/requests-route';
 
 const Requests = lazy(() => import(/* webpackChunkName: "requests" */ './smart-components/request/requests'));
 const RequestDetail = lazy(() => import(/* webpackChunkName: "request-detail" */ './smart-components/request/request-detail/request-detail'));
 const Workflows = lazy(() => import(/* webpackChunkName: "workflows" */ './smart-components/workflow/workflows'));
 const AllRequests = lazy(() => import(/* webpackChunkName: "requests" */ './smart-components/request/allrequests'));
+const errorPaths = [ '/400', '/401', '/403', '/404' ];
 
-const errorPaths = [ '/400', '/401', '/404' ];
+export const Routes = () => {
+  const { userRoles: userRoles } = useContext(UserContext);
 
-export const Routes = () => (
-  <Switch>
+  const defaultRequestPath = () => {
+    if (isApprovalApprover(userRoles)) {
+      return paths.requests.index;}
+
+    if (isApprovalAdmin(userRoles)) {
+      return paths.allrequests.index;
+    } else {
+      return errorPaths;
+    }
+  };
+
+  return <Switch>
     <ProtectedRoute path={ paths.workflows.index } component={ Workflows }/>
-    <Route path={ paths.requests.index } component={ Requests }/>
+    <RequestsRoute path={ paths.requests.index } component={ Requests }/>
     <Route path={ paths.allrequests.index } component={ AllRequests }/>
     <Route path={ paths.request.index } component={ RequestDetail }/>
-    <Route path={ errorPaths } component={ CommonApiError } />
+    <Route path={ errorPaths } component={ CommonApiError }/>
     <Route>
-      <Redirect to={ paths.requests.index } />
+      <Redirect to={ defaultRequestPath() }/>
     </Route>
-  </Switch>
-);
+  </Switch>;
+};

--- a/src/Routes.js
+++ b/src/Routes.js
@@ -1,7 +1,6 @@
-import { Route, Switch, Redirect } from 'react-router-dom';
+import { Route, Switch, Redirect, useLocation } from 'react-router-dom';
 import React, { lazy, useContext } from 'react';
 import ProtectedRoute from './routing/protected-route';
-import CommonApiError from './smart-components/error-pages/common-api-error';
 import paths from './constants/routes';
 import UserContext from './user-context';
 import { isApprovalAdmin, isApprovalApprover } from './helpers/shared/helpers';
@@ -11,10 +10,13 @@ const Requests = lazy(() => import(/* webpackChunkName: "requests" */ './smart-c
 const RequestDetail = lazy(() => import(/* webpackChunkName: "request-detail" */ './smart-components/request/request-detail/request-detail'));
 const Workflows = lazy(() => import(/* webpackChunkName: "workflows" */ './smart-components/workflow/workflows'));
 const AllRequests = lazy(() => import(/* webpackChunkName: "requests" */ './smart-components/request/allrequests'));
+const CommonApiError = lazy(() => import(/* webpackChunkName: "error-page" */ './smart-components/error-pages/common-api-error'));
+
 const errorPaths = [ '/400', '/401', '/403', '/404' ];
 
 export const Routes = () => {
   const { userRoles: userRoles } = useContext(UserContext);
+  const location = useLocation();
 
   const defaultRequestPath = () => {
     if (isApprovalApprover(userRoles)) {
@@ -22,8 +24,14 @@ export const Routes = () => {
 
     if (isApprovalAdmin(userRoles)) {
       return paths.allrequests.index;
-    } else {
-      return errorPaths;
+    }
+    else {
+      return {
+        pathname: '/403',
+        state: {
+          from: location
+        }
+      };
     }
   };
 

--- a/src/helpers/shared/helpers.js
+++ b/src/helpers/shared/helpers.js
@@ -44,5 +44,6 @@ export const approvalRoles = (roles) => {
   if (roles && roles.find(role => role.name === APPROVAL_APPROVER_ROLE) !== undefined) {
     userRoles[APPROVAL_APPROVER_ROLE] = true;
   }
+
   return userRoles;
 };

--- a/src/helpers/shared/helpers.js
+++ b/src/helpers/shared/helpers.js
@@ -14,10 +14,6 @@ export const scrollToTop = () => document.getElementById('root').scrollTo({
   left: 0
 });
 
-export const getCurrentPage = (limit = 1, offset = 0) => Math.floor(offset / limit) + 1;
-
-export const getNewPage = (page = 1, offset) => (page - 1) * offset;
-
 export const isRequestStateActive = (state) => activeStates.includes(state);
 
 export const timeAgo = (date) => (
@@ -26,15 +22,27 @@ export const timeAgo = (date) => (
   </span>
 );
 
-export const isApprovalAdmin = (persona) => (persona === APPROVAL_ADMIN_PERSONA);
-export const isApprovalApprover = (persona) => (persona === APPROVAL_ADMIN_PERSONA || persona === APPROVAL_APPROVER_PERSONA);
+export const isApprovalAdmin = (roles) => roles && roles[APPROVAL_ADMINISTRATOR_ROLE];
+export const isApprovalApprover = (roles) => roles && roles[APPROVAL_APPROVER_ROLE];
 
 export const approvalPersona = (userRoles) => {
-  if (userRoles && userRoles.find(role => role.name === APPROVAL_ADMINISTRATOR_ROLE) !== undefined) {
+  if (isApprovalAdmin(userRoles)) {
     return APPROVAL_ADMIN_PERSONA;
-  } else if (userRoles && userRoles.find(role => role.name === APPROVAL_APPROVER_ROLE) !== undefined) {
+  } else if (isApprovalApprover(userRoles)) {
     return APPROVAL_APPROVER_PERSONA;
   }
 
   return APPROVAL_REQUESTER_PERSONA;
+};
+
+export const approvalRoles = (roles) => {
+  const userRoles  = {};
+  if (roles && roles.find(role => role.name === APPROVAL_ADMINISTRATOR_ROLE) !== undefined) {
+    userRoles[APPROVAL_ADMINISTRATOR_ROLE] = true;
+  }
+
+  if (roles && roles.find(role => role.name === APPROVAL_APPROVER_ROLE) !== undefined) {
+    userRoles[APPROVAL_APPROVER_ROLE] = true;
+  }
+  return userRoles;
 };

--- a/src/helpers/shared/user-login.js
+++ b/src/helpers/shared/user-login.js
@@ -19,8 +19,25 @@ axiosInstance.interceptors.request.use(async config => {
   await window.insights.chrome.auth.getUser();
   return config;
 });
+
+const unauthorizedInterceptor = (error = {}) => {
+  if (error.status === 403) {
+    throw {
+      ...error,
+      redirect: {
+        pathname: '/403',
+        message: error.config?.url
+      }
+    };
+  }
+  else {
+    throw error;
+  }
+};
+
 axiosInstance.interceptors.response.use(resolveInterceptor);
 axiosInstance.interceptors.response.use(null, errorInterceptor);
+axiosInstance.interceptors.response.use(null, unauthorizedInterceptor);
 
 // Approval Apis
 

--- a/src/routing/protected-route.js
+++ b/src/routing/protected-route.js
@@ -4,15 +4,15 @@ import UserContext from '../user-context';
 import { isApprovalAdmin } from '../helpers/shared/helpers';
 
 const ProtectedRoute = (props) => {
-  const { userPersona: userPersona } = useContext(UserContext);
+  const { userRoles: userRoles } = useContext(UserContext);
   const location = useLocation();
 
-  return  isApprovalAdmin(userPersona) ? (
+  return  isApprovalAdmin(userRoles) ? (
     <Route { ...props } />
   ) : (
     <Redirect
       to={ {
-        pathname: '/401',
+        pathname: '/403',
         state: {
           from: location
         }

--- a/src/routing/requests-route.js
+++ b/src/routing/requests-route.js
@@ -1,0 +1,35 @@
+import React, { useContext } from 'react';
+import { Route, Redirect, useLocation } from 'react-router-dom';
+import UserContext from '../user-context';
+import paths from './../constants/routes';
+import { isApprovalAdmin, isApprovalApprover } from '../helpers/shared/helpers';
+
+const RequestsRoute = (props) => {
+  const { userRoles: userRoles } = useContext(UserContext);
+  const location = useLocation();
+
+  if (isApprovalApprover(userRoles)) {
+    return <Route { ...props } />;
+  } else if (isApprovalAdmin(userRoles)) {
+    return <Redirect
+      to={ {
+        pathname: paths.allrequests,
+        state: {
+          from: location
+        }
+      } }
+    />;
+  }
+  else {
+    return <Redirect
+      to={ {
+        pathname: '/403',
+        state: {
+          from: location
+        }
+      } }
+    />;
+  }
+};
+
+export default RequestsRoute;

--- a/src/smart-components/app-tabs/app-tabs.js
+++ b/src/smart-components/app-tabs/app-tabs.js
@@ -22,7 +22,6 @@ export const AppTabs = () => {
   const handleTabClick = (_event, tabIndex) =>
     history.push({ pathname: tabItems[tabIndex].name, search });
 
-  console.log('Debug - tabItems', tabItems);
   return (
     <Tabs className="pf-u-mt-sm" activeKey={ activeTab ? activeTab.eventKey : 0 } onSelect={ handleTabClick }>
       { tabItems.map((item) => <Tab title={ item.title } key={ item.eventKey } eventKey={ item.eventKey } name={ item.name }/>) }

--- a/src/smart-components/app-tabs/app-tabs.js
+++ b/src/smart-components/app-tabs/app-tabs.js
@@ -1,19 +1,28 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { useLocation, useHistory } from 'react-router-dom';
 import { Tabs, Tab } from '@patternfly/react-core';
+import UserContext from '../../user-context';
+import { isApprovalApprover } from '../../helpers/shared/helpers';
 
-const approvalTabItems = [{ eventKey: 0, title: 'Request queue', name: '/requests' },
+export const approvalTabItems = [{ eventKey: 0, title: 'Request queue', name: '/requests' },
   { eventKey: 1, title: 'All requests', name: '/allrequests' },
   { eventKey: 2, title: 'Approval processes', name: '/workflows' }];
 
-export const AppTabs = ({ tabItems = approvalTabItems }) => {
+export const adminTabItems = [{ eventKey: 0, title: 'All requests', name: '/allrequests' },
+  { eventKey: 1, title: 'Approval processes', name: '/workflows' }];
+
+export const AppTabs = () => {
   const history = useHistory();
   const { pathname, search } = useLocation();
+  const { userRoles: userRoles } = useContext(UserContext);
+  const tabItems = isApprovalApprover(userRoles) ? approvalTabItems : adminTabItems;
+
   const activeTab = tabItems.find(({ name }) => pathname.includes(name));
   const handleTabClick = (_event, tabIndex) =>
     history.push({ pathname: tabItems[tabIndex].name, search });
 
+  console.log('Debug - tabItems', tabItems);
   return (
     <Tabs className="pf-u-mt-sm" activeKey={ activeTab ? activeTab.eventKey : 0 } onSelect={ handleTabClick }>
       { tabItems.map((item) => <Tab title={ item.title } key={ item.eventKey } eventKey={ item.eventKey } name={ item.name }/>) }

--- a/src/smart-components/error-pages/common-api-error.js
+++ b/src/smart-components/error-pages/common-api-error.js
@@ -12,7 +12,7 @@ import Exclamation from '@patternfly/react-icons/dist/js/icons/exclamation-icon'
 
 const TITLES = {
   '/401': 'Unauthorized',
-  '/403': 'Unauthorized'
+  '/403': 'Forbidden'
 };
 
 const MESSAGES = {
@@ -21,10 +21,7 @@ const MESSAGES = {
 };
 
 const CommonApiError = () => {
-  const {
-    state: { from },
-    pathname
-  } = useLocation();
+  const { state, pathname } = useLocation();
 
   return (
     <Bullseye className="global-primary-background">
@@ -36,8 +33,13 @@ const CommonApiError = () => {
           <Title size="lg">{ TITLES[pathname] }</Title>
         </div>
         <EmptyStateBody>
-          { MESSAGES[pathname] } { from.pathname }. If you believe this is a
-          mistake, please contact support.
+          { MESSAGES[pathname] }
+          <span>
+            { state?.from?.pathname }
+            { state?.from?.search }
+          </span>
+          <br />
+          If you believe this is a mistake, please contact support.
         </EmptyStateBody>
         <EmptyStatePrimary>
           <Link to="/" >Return to approval</Link>

--- a/src/smart-components/error-pages/common-api-error.js
+++ b/src/smart-components/error-pages/common-api-error.js
@@ -11,11 +11,13 @@ import {
 import Exclamation from '@patternfly/react-icons/dist/js/icons/exclamation-icon';
 
 const TITLES = {
-  '/401': 'Unauthorized'
+  '/401': 'Unauthorized',
+  '/403': 'Unauthorized'
 };
 
 const MESSAGES = {
-  '/401': 'You are not authorized to access this section: '
+  '/401': 'You are not authorized to access this section: ',
+  '/403': 'You are not authorized to access this section: '
 };
 
 const CommonApiError = () => {

--- a/src/smart-components/request/expandable-content.js
+++ b/src/smart-components/request/expandable-content.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import { TextContent, Text, TextVariants, Level, LevelItem, Button, Bullseye, Spinner } from '@patternfly/react-core';
-import { isApprovalApprover, isRequestStateActive } from '../../helpers/shared/helpers';
+import { isApprovalAdmin, isApprovalApprover, isRequestStateActive } from '../../helpers/shared/helpers';
 import { fetchRequestContent } from '../../helpers/request/request-helper';
 import UserContext from '../../user-context';
 import routes from '../../constants/routes';
@@ -25,7 +25,7 @@ const ExpandableContent = ({ id, number_of_children, state, reason }) => {
   const [ requestContent, setRequestContent ] = useState([]);
   const [ isLoading, setIsLoading ] = useState(true);
   const [ fetchStarted, setIsFetching ] = useState(false);
-  const { userPersona: userPersona } = useContext(UserContext);
+  const { userRoles: userRoles } = useContext(UserContext);
   const expandedRequests = useSelector(({ requestReducer: { expandedRequests }}) => expandedRequests);
 
   useEffect(() => {
@@ -47,7 +47,7 @@ const ExpandableContent = ({ id, number_of_children, state, reason }) => {
         <LevelItem>
           <ExpandedItem title="Product" detail={ requestContent ? requestContent.product : 'Unknown' } />
         </LevelItem>
-        { requestActive && isApprovalApprover(userPersona) && <LevelItem>
+        { requestActive && (isApprovalApprover(userRoles) || isApprovalAdmin(userRoles)) && <LevelItem>
           <Link to={ { pathname: routes.requests.approve, search: `request=${id}` } }  className="pf-u-mr-md">
             <Button variant="primary" aria-label="Approve Request" isDisabled={ !requestActive }>
               Approve

--- a/src/smart-components/request/request-detail/request-detail.js
+++ b/src/smart-components/request/request-detail/request-detail.js
@@ -12,6 +12,7 @@ import { TopToolbar, TopToolbarTitle } from '../../../presentational-components/
 import UserContext from '../../../user-context';
 import useQuery from '../../../utilities/use-query';
 import routes from '../../../constants/routes';
+import { approvalPersona } from '../../../helpers/shared/helpers';
 
 const initialState = {
   isFetching: true
@@ -40,10 +41,10 @@ const RequestDetail = () => {
   const [{ request: id }, search ] = useQuery([ 'request' ]);
   const location = useLocation();
   const dispatch = useDispatch();
-  const { userPersona: userPersona } = useContext(UserContext);
+  const { userRoles: userRoles } = useContext(UserContext);
 
   useEffect(() => {
-    Promise.all([ dispatch(fetchRequest(id, userPersona)), dispatch(fetchRequestContent(id, userPersona)) ])
+    Promise.all([ dispatch(fetchRequest(id, approvalPersona(userRoles))), dispatch(fetchRequestContent(id, approvalPersona(userRoles))) ])
     .then(() => stateDispatch({ type: 'setFetching', payload: false }));
   }, []);
 

--- a/src/smart-components/request/request-detail/request.js
+++ b/src/smart-components/request/request-detail/request.js
@@ -28,7 +28,7 @@ import routes from '../../../constants/routes';
 
 export const Request = ({ item, isExpanded, toggleExpand }) => {
   const [ isKebabOpen, setIsKebabOpen ] = useState(false);
-  const { userPersona: userPersona } = useContext(UserContext);
+  const { userRoles: userRoles } = useContext(UserContext);
 
   const onKebabToggle = isOpen => {
     setIsKebabOpen(isOpen);
@@ -39,7 +39,7 @@ export const Request = ({ item, isExpanded, toggleExpand }) => {
   };
 
   const checkCapability = (item, capability) => {
-    if (isApprovalAdmin(userPersona)) {
+    if (isApprovalAdmin(userRoles)) {
       return true;
     }
 

--- a/src/smart-components/request/requests-list.js
+++ b/src/smart-components/request/requests-list.js
@@ -78,7 +78,7 @@ const RequestsList = ({ routes, persona, actionResolver }) => {
     initialState(filterValue.name, filterValue.requester)
   );
 
-  const { userPersona: userPersona } = useContext(UserContext);
+  const { userRoles: userRoles } = useContext(UserContext);
 
   const dispatch = useDispatch();
   const intl = useIntl();
@@ -147,7 +147,7 @@ const RequestsList = ({ routes, persona, actionResolver }) => {
     <Fragment>
       <TopToolbar>
         <TopToolbarTitle title="Approval"/>
-        { isApprovalAdmin(userPersona) && <AppTabs/> }
+        { isApprovalAdmin(userRoles) && <AppTabs/> }
       </TopToolbar>
       <TableToolbarView
         sortBy={ sortBy }

--- a/src/smart-components/request/requests.js
+++ b/src/smart-components/request/requests.js
@@ -3,7 +3,7 @@ import { Route, useHistory } from 'react-router-dom';
 import { fetchRequests } from '../../redux/actions/request-actions';
 import ActionModal from './action-modal';
 import {
-  APPROVAL_APPROVER_PERSONA,
+  APPROVAL_APPROVER_PERSONA, isApprovalAdmin,
   isApprovalApprover,
   isRequestStateActive
 } from '../../helpers/shared/helpers';
@@ -12,7 +12,7 @@ import routesLinks from '../../constants/routes';
 import RequestsList from './requests-list';
 
 const Requests = () => {
-  const { userPersona: userPersona } = useContext(UserContext);
+  const { userRoles: userRoles } = useContext(UserContext);
   const history = useHistory();
 
   const routes = () => <Fragment>
@@ -27,7 +27,8 @@ const Requests = () => {
 
   const actionsDisabled = (requestData) => requestData &&
     requestData.state ?
-    !isRequestStateActive(requestData.state) || requestData.number_of_children > 0 || !isApprovalApprover(userPersona) : true;
+    !isRequestStateActive(requestData.state) || requestData.number_of_children > 0 ||
+      (!isApprovalApprover(userRoles) && !isApprovalAdmin(userRoles)) : true;
 
   const actionResolver = (requestData) => {
     return (requestData && requestData.id && actionsDisabled(requestData) ? null :

--- a/src/test/helpers/shared/helpers.test.js
+++ b/src/test/helpers/shared/helpers.test.js
@@ -10,20 +10,26 @@ import {
 describe('Shared helpers', () => {
   describe('#approvalPersona', () => {
     let roles;
+
+    beforeEach(() => {
+      roles = {};
+    });
+
     it('is admin', () => {
-      roles = [{ name: APPROVAL_APPROVER_ROLE }, { name: APPROVAL_ADMINISTRATOR_ROLE }];
+      roles[APPROVAL_APPROVER_ROLE] = true;
+      roles[APPROVAL_ADMINISTRATOR_ROLE] = true;
 
       expect(approvalPersona(roles)).toEqual(APPROVAL_ADMIN_PERSONA);
     });
 
     it('is approver', () => {
-      roles = [{ name: APPROVAL_APPROVER_ROLE }];
+      roles[APPROVAL_APPROVER_ROLE] = true;
 
       expect(approvalPersona(roles)).toEqual(APPROVAL_APPROVER_PERSONA);
     });
 
     it('is requester', () => {
-      roles = [{ name: 'non-sense' }];
+      roles = [{}];
 
       expect(approvalPersona(roles)).toEqual(APPROVAL_REQUESTER_PERSONA);
     });

--- a/src/test/routing/protected-route.test.js
+++ b/src/test/routing/protected-route.test.js
@@ -1,7 +1,6 @@
 import { MemoryRouter, Route, Redirect } from 'react-router-dom';
 import UserContext from '../../user-context';
 import ProtectedRoute from '../../routing/protected-route';
-import { APPROVAL_ADMIN_PERSONA, APPROVAL_REQUESTER_PERSONA } from '../../helpers/shared/helpers';
 
 describe('<ProtectedRoute />', () => {
   const ComponentWrapper = ({ children, value }) => <MemoryRouter initialEntries={ [ '/initial' ] } initialIndex={ 0 }>
@@ -14,7 +13,7 @@ describe('<ProtectedRoute />', () => {
 
   it('is admin', () => {
     const wrapper = mount(
-      <ComponentWrapper value={ { userPersona: APPROVAL_ADMIN_PERSONA } }>
+      <ComponentWrapper value={ { userRoles: { APPROVAL_ADMIN_ROLE: true }} }>
         <ProtectedRoute />
       </ComponentWrapper>
     );
@@ -26,7 +25,7 @@ describe('<ProtectedRoute />', () => {
 
   it('is not admin', () => {
     const wrapper = mount(
-      <ComponentWrapper value={ { userPersona: APPROVAL_REQUESTER_PERSONA } }>
+      <ComponentWrapper value={ { userRoles: {}} }>
         <ProtectedRoute />
       </ComponentWrapper>
     );

--- a/src/test/routing/protected-route.test.js
+++ b/src/test/routing/protected-route.test.js
@@ -1,6 +1,7 @@
 import { MemoryRouter, Route, Redirect } from 'react-router-dom';
 import UserContext from '../../user-context';
 import ProtectedRoute from '../../routing/protected-route';
+import { APPROVAL_ADMINISTRATOR_ROLE } from '../../helpers/shared/helpers';
 
 describe('<ProtectedRoute />', () => {
   const ComponentWrapper = ({ children, value }) => <MemoryRouter initialEntries={ [ '/initial' ] } initialIndex={ 0 }>
@@ -12,8 +13,10 @@ describe('<ProtectedRoute />', () => {
   </MemoryRouter>;
 
   it('is admin', () => {
+    const roles = {};
+    roles[APPROVAL_ADMINISTRATOR_ROLE] = true;
     const wrapper = mount(
-      <ComponentWrapper value={ { userRoles: { APPROVAL_ADMIN_ROLE: true }} }>
+      <ComponentWrapper value={ { userRoles: roles } }>
         <ProtectedRoute />
       </ComponentWrapper>
     );
@@ -31,6 +34,6 @@ describe('<ProtectedRoute />', () => {
     );
 
     expect(wrapper.find(Route)).toHaveLength(1);
-    expect(wrapper.find(MemoryRouter).instance().history.location.pathname).toEqual('/401');
+    expect(wrapper.find(MemoryRouter).instance().history.location.pathname).toEqual('/403');
   });
 });

--- a/src/test/smart-components/request/expandable-content.test.js
+++ b/src/test/smart-components/request/expandable-content.test.js
@@ -55,7 +55,7 @@ describe('requests - expendableContent', () => {
 
     const ComponentWrapper = ({ store, children }) => (
       <Provider store={ store }>
-        <UserContext.Provider value={ { userPersona: 'approval/requester' } }>
+        <UserContext.Provider value={ { userRoles: {}} }>
           <MemoryRouter initialEntries={ [ '' ] }>
             { children }
           </MemoryRouter>

--- a/src/test/smart-components/request/request-detail/request-detail.test.js
+++ b/src/test/smart-components/request/request-detail/request-detail.test.js
@@ -275,10 +275,11 @@ describe('<RequestDetail />', () => {
       mockGraphql.onPost(`${APPROVAL_API_BASE}/graphql`).replyOnce(200, graphlQlData);
 
       let wrapper;
+      roles[APPROVAL_ADMINISTRATOR_ROLE] = true;
 
       await act(async() => {
         wrapper = mount(
-          <UserContext.Provider value={ { userRoles: { APPROVAL_ADMIN_ROLE: true }} }>
+          <UserContext.Provider value={ { userRoles: roles } }>
             <ComponentWrapper store={ store }>
               <RequestDetail { ...initialProps } />
             </ComponentWrapper>
@@ -307,6 +308,7 @@ describe('<RequestDetail />', () => {
 
       let wrapper;
       roles[APPROVAL_ADMINISTRATOR_ROLE] = true;
+
       await act(async() => {
         wrapper = mount(
           <UserContext.Provider value={ { userRoles: roles } }>

--- a/src/test/smart-components/request/request-detail/request-detail.test.js
+++ b/src/test/smart-components/request/request-detail/request-detail.test.js
@@ -17,7 +17,6 @@ import { BreadcrumbItem } from '@patternfly/react-core';
 import routes from '../../../../constants/routes';
 import ReducerRegistry, { applyReducerHash } from '@redhat-cloud-services/frontend-components-utilities/files/ReducerRegistry';
 import requestReducer, { requestsInitialState } from '../../../../redux/reducers/request-reducer';
-import { APPROVAL_ADMIN_PERSONA } from '../../../../helpers/shared/helpers';
 import UserContext from '../../../../user-context';
 import ActionModal from '../../../../smart-components/request/action-modal';
 
@@ -240,7 +239,7 @@ describe('<RequestDetail />', () => {
 
       await act(async() => {
         wrapper = mount(
-          <UserContext.Provider value={ { userPersona: APPROVAL_ADMIN_PERSONA } }>
+          <UserContext.Provider value={ { userRoles: { APPROVAL_ADMIN_ROLE: true }} }>
             <ComponentWrapper store={ store }>
               <RequestDetail { ...initialProps } />
             </ComponentWrapper>
@@ -275,7 +274,7 @@ describe('<RequestDetail />', () => {
 
       await act(async() => {
         wrapper = mount(
-          <UserContext.Provider value={ { userPersona: APPROVAL_ADMIN_PERSONA } }>
+          <UserContext.Provider value={ { userRoles: { APPROVAL_ADMIN_ROLE: true }} }>
             <ComponentWrapper store={ store }>
               <RequestDetail { ...initialProps } />
             </ComponentWrapper>
@@ -306,7 +305,7 @@ describe('<RequestDetail />', () => {
 
       await act(async() => {
         wrapper = mount(
-          <UserContext.Provider value={ { userPersona: APPROVAL_ADMIN_PERSONA } }>
+          <UserContext.Provider value={ { userRoles: { APPROVAL_ADMIN_ROLE: true }} }>
             <ComponentWrapper store={ store }>
               <RequestDetail { ...initialProps } />
             </ComponentWrapper>

--- a/src/test/smart-components/request/request-detail/request-detail.test.js
+++ b/src/test/smart-components/request/request-detail/request-detail.test.js
@@ -19,6 +19,7 @@ import ReducerRegistry, { applyReducerHash } from '@redhat-cloud-services/fronte
 import requestReducer, { requestsInitialState } from '../../../../redux/reducers/request-reducer';
 import UserContext from '../../../../user-context';
 import ActionModal from '../../../../smart-components/request/action-modal';
+import { APPROVAL_ADMINISTRATOR_ROLE } from '../../../../helpers/shared/helpers';
 
 const ComponentWrapper = ({ store, children, initialEntries = [ '/foo?request=123' ]}) => (
   <Provider store={ store } >
@@ -33,6 +34,7 @@ describe('<RequestDetail />', () => {
   const middlewares = [ thunk, promiseMiddleware(), notificationsMiddleware() ];
   let mockStore;
   let initialState;
+  let roles;
 
   beforeEach(() => {
     initialProps = {
@@ -40,6 +42,7 @@ describe('<RequestDetail />', () => {
         title: 'Foo'
       }]
     };
+    roles = {};
     mockStore = configureStore(middlewares);
     initialState = {
       requestReducer: {
@@ -236,10 +239,11 @@ describe('<RequestDetail />', () => {
       mockGraphql.onPost(`${APPROVAL_API_BASE}/graphql`).replyOnce(200, graphlQlData);
 
       let wrapper;
+      roles[APPROVAL_ADMINISTRATOR_ROLE] = true;
 
       await act(async() => {
         wrapper = mount(
-          <UserContext.Provider value={ { userRoles: { APPROVAL_ADMIN_ROLE: true }} }>
+          <UserContext.Provider value={ { userRoles: roles } }>
             <ComponentWrapper store={ store }>
               <RequestDetail { ...initialProps } />
             </ComponentWrapper>
@@ -302,10 +306,10 @@ describe('<RequestDetail />', () => {
       mockGraphql.onPost(`${APPROVAL_API_BASE}/graphql`).replyOnce(200, graphlQlData);
 
       let wrapper;
-
+      roles[APPROVAL_ADMINISTRATOR_ROLE] = true;
       await act(async() => {
         wrapper = mount(
-          <UserContext.Provider value={ { userRoles: { APPROVAL_ADMIN_ROLE: true }} }>
+          <UserContext.Provider value={ { userRoles: roles } }>
             <ComponentWrapper store={ store }>
               <RequestDetail { ...initialProps } />
             </ComponentWrapper>

--- a/src/test/smart-components/request/requests.test.js
+++ b/src/test/smart-components/request/requests.test.js
@@ -16,6 +16,7 @@ import TableEmptyState from '../../../presentational-components/shared/table-emp
 import UserContext from '../../../user-context';
 import routes from '../../../constants/routes';
 import ActionModal from '../../../smart-components/request/action-modal';
+import { APPROVAL_ADMINISTRATOR_ROLE } from '../../../helpers/shared/helpers';
 
 const ComponentWrapper = ({ store, initialEntries = [ '/requests' ], children }) => (
   <Provider store={ store } value={ { roles: []} }>
@@ -555,9 +556,11 @@ describe('<Requests />', () => {
       const store = registry.getStore();
 
       let wrapper;
+      const roles = {};
+      roles[APPROVAL_ADMINISTRATOR_ROLE] = true;
       await act(async () => {
         wrapper = mount(
-          <UserContext.Provider value={ { userRoles: { APPROVAL_ADMIN_ROLE: true }} } >
+          <UserContext.Provider value={ { userRoles: roles } } >
             <ComponentWrapper store={ store }><Requests { ...initialProps } /></ComponentWrapper>
           </UserContext.Provider>
         );
@@ -595,7 +598,7 @@ describe('<Requests />', () => {
       let wrapper;
       await act(async () => {
         wrapper = mount(
-          <UserContext.Provider value={ { userRoles: { APPROVAL_ADMIN_ROLE: true }} } >
+          <UserContext.Provider value={ { userRoles: { APPROVAL_APPROVER_ROLE: true }} } >
             <ComponentWrapper store={ store }><Requests { ...initialProps } /></ComponentWrapper>
           </UserContext.Provider>
         );
@@ -633,7 +636,7 @@ describe('<Requests />', () => {
       let wrapper;
       await act(async () => {
         wrapper = mount(
-          <UserContext.Provider value={ { userRoles: { APPROVAL_ADMIN_ROLE: true }} } >
+          <UserContext.Provider value={ { userRoles: { APPROVAL_APPROVER_ROLE: true }} } >
             <ComponentWrapper store={ store }><Requests { ...initialProps } /></ComponentWrapper>
           </UserContext.Provider>
         );

--- a/src/test/smart-components/request/requests.test.js
+++ b/src/test/smart-components/request/requests.test.js
@@ -16,7 +16,7 @@ import TableEmptyState from '../../../presentational-components/shared/table-emp
 import UserContext from '../../../user-context';
 import routes from '../../../constants/routes';
 import ActionModal from '../../../smart-components/request/action-modal';
-import { APPROVAL_ADMINISTRATOR_ROLE } from '../../../helpers/shared/helpers';
+import { APPROVAL_ADMINISTRATOR_ROLE, APPROVAL_APPROVER_ROLE } from '../../../helpers/shared/helpers';
 
 const ComponentWrapper = ({ store, initialEntries = [ '/requests' ], children }) => (
   <Provider store={ store } value={ { roles: []} }>
@@ -540,7 +540,10 @@ describe('<Requests />', () => {
       portfolio: 'LGTestNoTags'
     };
 
+    let roles = {};
+
     beforeEach(() => {
+      roles = {};
       apiClientMock.get(`${APPROVAL_API_BASE}/requests/?limit=50&offset=0&sort_by=created_at%3Adesc`, mockOnce({
         status: 200,
         body: {
@@ -556,7 +559,6 @@ describe('<Requests />', () => {
       const store = registry.getStore();
 
       let wrapper;
-      const roles = {};
       roles[APPROVAL_ADMINISTRATOR_ROLE] = true;
       await act(async () => {
         wrapper = mount(
@@ -594,11 +596,12 @@ describe('<Requests />', () => {
       const registry = new ReducerRegistry({}, [ thunk, promiseMiddleware() ]);
       registry.register({ requestReducer: applyReducerHash(requestReducer, requestsInitialState) });
       const store = registry.getStore();
+      roles[APPROVAL_APPROVER_ROLE] = true;
 
       let wrapper;
       await act(async () => {
         wrapper = mount(
-          <UserContext.Provider value={ { userRoles: { APPROVAL_APPROVER_ROLE: true }} } >
+          <UserContext.Provider value={ { userRoles: roles } } >
             <ComponentWrapper store={ store }><Requests { ...initialProps } /></ComponentWrapper>
           </UserContext.Provider>
         );
@@ -634,9 +637,10 @@ describe('<Requests />', () => {
       const store = registry.getStore();
 
       let wrapper;
+      roles[APPROVAL_APPROVER_ROLE] = true;
       await act(async () => {
         wrapper = mount(
-          <UserContext.Provider value={ { userRoles: { APPROVAL_APPROVER_ROLE: true }} } >
+          <UserContext.Provider value={ { userRoles: roles } } >
             <ComponentWrapper store={ store }><Requests { ...initialProps } /></ComponentWrapper>
           </UserContext.Provider>
         );

--- a/src/test/smart-components/request/requests.test.js
+++ b/src/test/smart-components/request/requests.test.js
@@ -13,7 +13,6 @@ import { RowWrapper } from '@patternfly/react-table';
 import { Table } from '@patternfly/react-table';
 import { APPROVAL_API_BASE } from '../../../utilities/constants';
 import TableEmptyState from '../../../presentational-components/shared/table-empty-state';
-import { APPROVAL_ADMIN_PERSONA } from '../../../helpers/shared/helpers';
 import UserContext from '../../../user-context';
 import routes from '../../../constants/routes';
 import ActionModal from '../../../smart-components/request/action-modal';
@@ -558,7 +557,7 @@ describe('<Requests />', () => {
       let wrapper;
       await act(async () => {
         wrapper = mount(
-          <UserContext.Provider value={ { userPersona: APPROVAL_ADMIN_PERSONA } } >
+          <UserContext.Provider value={ { userRoles: { APPROVAL_ADMIN_ROLE: true }} } >
             <ComponentWrapper store={ store }><Requests { ...initialProps } /></ComponentWrapper>
           </UserContext.Provider>
         );
@@ -596,7 +595,7 @@ describe('<Requests />', () => {
       let wrapper;
       await act(async () => {
         wrapper = mount(
-          <UserContext.Provider value={ { userPersona: APPROVAL_ADMIN_PERSONA } } >
+          <UserContext.Provider value={ { userRoles: { APPROVAL_ADMIN_ROLE: true }} } >
             <ComponentWrapper store={ store }><Requests { ...initialProps } /></ComponentWrapper>
           </UserContext.Provider>
         );
@@ -634,7 +633,7 @@ describe('<Requests />', () => {
       let wrapper;
       await act(async () => {
         wrapper = mount(
-          <UserContext.Provider value={ { userPersona: APPROVAL_ADMIN_PERSONA } } >
+          <UserContext.Provider value={ { userRoles: { APPROVAL_ADMIN_ROLE: true }} } >
             <ComponentWrapper store={ store }><Requests { ...initialProps } /></ComponentWrapper>
           </UserContext.Provider>
         );

--- a/src/test/smart-components/workflow/workflows.test.js
+++ b/src/test/smart-components/workflow/workflows.test.js
@@ -410,7 +410,7 @@ describe('<Workflows />', () => {
     );
 
     await act(async () => {
-      wrapper.find('button').at(11).simulate('click'); // name column
+      wrapper.find('button').at(10).simulate('click'); // name column
     });
     wrapper.update();
 
@@ -428,7 +428,7 @@ describe('<Workflows />', () => {
     );
 
     await act(async () => {
-      wrapper.find('button').at(11).simulate('click'); // name column
+      wrapper.find('button').at(10).simulate('click'); // name column
     });
     wrapper.update();
 
@@ -446,7 +446,7 @@ describe('<Workflows />', () => {
     );
 
     await act(async () => {
-      wrapper.find('button').at(12).simulate('click'); // description column
+      wrapper.find('button').at(11).simulate('click'); // description column
     });
     wrapper.update();
   });


### PR DESCRIPTION
Fixes https://projects.engineering.redhat.com/browse/SSP-1563
Only display the request queue for a user with the Approval Approver roles.
1. For a user that has the Approval Administrator role but not the Approval Approver role, display all 3 tabs ( Request Queue, All Requests and Approval Processes.
2. For a user with Approval Approver role only, display the request queue only
3. For a user with no Approval Admin or Approval Approver, display the 403 error page

1. Admin role, no approver role:
![Screenshot from 2020-05-28 23-11-35](https://user-images.githubusercontent.com/12769982/83217028-9e0b4280-a138-11ea-8265-e040ec095cc0.png)

Admin and approver roles
![Screenshot from 2020-05-28 23-09-15](https://user-images.githubusercontent.com/12769982/83217032-9ea3d900-a138-11ea-943d-8d043a82c0ab.png)

Non admin and non approver roles
![Screenshot from 2020-05-28 23-09-55](https://user-images.githubusercontent.com/12769982/83217030-9ea3d900-a138-11ea-9c3c-56ccf649ba82.png)



