### PR TITLE
Disable buttons on allrequests tab

### DIFF
--- a/src/presentational-components/shared/table-toolbar-view.js
+++ b/src/presentational-components/shared/table-toolbar-view.js
@@ -42,7 +42,7 @@ export const TableToolbarView = ({
   const [ rows, setRows ] = useState([]);
 
   useEffect(() => {
-    setRows(createRows(data, actionsDisabled ));
+    setRows(createRows(data, actionsDisabled));
   }, [ data ]);
 
   const setOpen = (data, id) => data.map(row => row.id === id ?

--- a/src/presentational-components/shared/table-toolbar-view.js
+++ b/src/presentational-components/shared/table-toolbar-view.js
@@ -22,6 +22,7 @@ export const TableToolbarView = ({
   toolbarButtons,
   data,
   actionResolver,
+  actionsDisabled,
   routes,
   titlePlural,
   titleSingular,
@@ -41,7 +42,7 @@ export const TableToolbarView = ({
   const [ rows, setRows ] = useState([]);
 
   useEffect(() => {
-    setRows(createRows(data));
+    setRows(createRows(data, actionsDisabled ));
   }, [ data ]);
 
   const setOpen = (data, id) => data.map(row => row.id === id ?
@@ -185,6 +186,5 @@ TableToolbarView.defaultProps = {
   pagination: defaultSettings,
   isSelectable: null,
   routes: () => null,
-  renderEmptyState: () => null,
   filterConfig: []
 };

--- a/src/presentational-components/shared/table-toolbar-view.js
+++ b/src/presentational-components/shared/table-toolbar-view.js
@@ -177,7 +177,8 @@ TableToolbarView.propTypes = {
   sortBy: propTypes.object,
   onSort: propTypes.func,
   activeFiltersConfig: propTypes.object,
-  filterConfig: propTypes.array
+  filterConfig: propTypes.array,
+  actionsDisabled: propTypes.func
 };
 
 TableToolbarView.defaultProps = {
@@ -186,5 +187,6 @@ TableToolbarView.defaultProps = {
   pagination: defaultSettings,
   isSelectable: null,
   routes: () => null,
+  renderEmptyState: () => null,
   filterConfig: []
 };

--- a/src/smart-components/request/expandable-content.js
+++ b/src/smart-components/request/expandable-content.js
@@ -20,7 +20,7 @@ ExpandedItem.propTypes = {
   detail: PropTypes.node
 };
 
-const ExpandableContent = ({ id, number_of_children, state, reason, actionsDisabled = true }) => {
+const ExpandableContent = ({ id, number_of_children, state, reason, actionsDisabled }) => {
   const requestActive = isRequestStateActive(state) && !number_of_children;
   const [ requestContent, setRequestContent ] = useState([]);
   const [ isLoading, setIsLoading ] = useState(true);
@@ -49,7 +49,7 @@ const ExpandableContent = ({ id, number_of_children, state, reason, actionsDisab
         <LevelItem>
           <ExpandedItem title="Product" detail={ requestContent ? requestContent.product : 'Unknown' } />
         </LevelItem>
-        { requestActive && (isApprovalApprover || isApprovalAdmin) && <LevelItem>
+        { requestActive && (isApprovalApprover || isApprovalAdmin) && !actionsDisabled && <LevelItem>
           <Link to={ { pathname: routes.requests.approve, search: `request=${id}` } }  className="pf-u-mr-md">
             <Button variant="primary" aria-label="Approve Request" isDisabled={ !requestActive }>
               Approve
@@ -73,13 +73,18 @@ const ExpandableContent = ({ id, number_of_children, state, reason, actionsDisab
   );
 };
 
+ExpandableContent.defaultProps = {
+  actionsDisabled: true
+};
+
 ExpandableContent.propTypes = {
   id: PropTypes.string,
   content: PropTypes.object,
   number_of_children: PropTypes.number,
   uname: PropTypes.string,
   state: PropTypes.string,
-  reason: PropTypes.string
+  reason: PropTypes.string,
+  actionsDisabled: PropTypes.bool
 };
 
 export default ExpandableContent;

--- a/src/smart-components/request/expandable-content.js
+++ b/src/smart-components/request/expandable-content.js
@@ -20,7 +20,7 @@ ExpandedItem.propTypes = {
   detail: PropTypes.node
 };
 
-const ExpandableContent = ({ id, number_of_children, state, reason }) => {
+const ExpandableContent = ({ id, number_of_children, state, reason, actionsDisabled = true }) => {
   const requestActive = isRequestStateActive(state) && !number_of_children;
   const [ requestContent, setRequestContent ] = useState([]);
   const [ isLoading, setIsLoading ] = useState(true);

--- a/src/smart-components/request/request-table-helpers.js
+++ b/src/smart-components/request/request-table-helpers.js
@@ -9,7 +9,7 @@ import { decisionValues } from '../../utilities/constants';
 const decisionIcon = (decision) => decisionValues[decision] ? decisionValues[decision].icon : '';
 const decisionDisplayName = (decision) => decisionValues[decision] ? decisionValues[decision].displayName : '';
 
-export const createRows = (data) =>
+export const createRows = (data, actionsDisabled ) =>
   data.reduce((acc, { id,
     name,
     requester_name,
@@ -42,7 +42,7 @@ export const createRows = (data) =>
       parent: key * 2,
       fullWidth: true,
       cells: [{
-        title: <ExpandableContent id={ id }
+        title: <ExpandableContent actionsDisabled={actionsDisabled} id={ id }
           number_of_children={ number_of_children }
           state={ state }
           reason={ reason }/>

--- a/src/smart-components/request/request-table-helpers.js
+++ b/src/smart-components/request/request-table-helpers.js
@@ -9,7 +9,7 @@ import { decisionValues } from '../../utilities/constants';
 const decisionIcon = (decision) => decisionValues[decision] ? decisionValues[decision].icon : '';
 const decisionDisplayName = (decision) => decisionValues[decision] ? decisionValues[decision].displayName : '';
 
-export const createRows = (data, actionsDisabled ) =>
+export const createRows = (data, actionsDisabled) =>
   data.reduce((acc, { id,
     name,
     requester_name,
@@ -42,7 +42,7 @@ export const createRows = (data, actionsDisabled ) =>
       parent: key * 2,
       fullWidth: true,
       cells: [{
-        title: <ExpandableContent actionsDisabled={actionsDisabled} id={ id }
+        title: <ExpandableContent actionsDisabled={ actionsDisabled } id={ id }
           number_of_children={ number_of_children }
           state={ state }
           reason={ reason }/>

--- a/src/smart-components/request/request-table-helpers.js
+++ b/src/smart-components/request/request-table-helpers.js
@@ -9,44 +9,32 @@ import { decisionValues } from '../../utilities/constants';
 const decisionIcon = (decision) => decisionValues[decision] ? decisionValues[decision].icon : '';
 const decisionDisplayName = (decision) => decisionValues[decision] ? decisionValues[decision].displayName : '';
 
-export const createRows = (data, actionsDisabled) =>
-  data.reduce((acc, { id,
-    name,
-    requester_name,
-    created_at,
-    notified_at,
-    finished_at,
-    state,
-    decision,
-    reason,
-    number_of_children
-  }, key) => ([
-    ...acc, {
-      id,
-      isOpen: false,
-      state,
-      number_of_children,
-      cells: [
-        <Fragment key={ id }><Link to={ { pathname: routes.request.index, search: `?request=${id}` } }>{ id }</Link></Fragment>,
-        name,
-        requester_name,
-        timeAgo(created_at),
-        finished_at ? timeAgo(finished_at) : (notified_at ? timeAgo(notified_at) : timeAgo(created_at)),
-        state,
-        <Fragment key={ `decision-${id}` }><Text key={ `${decision}-$(id}` } style={ { marginBottom: 0 } }
-          className="data-table-detail content">
-          { decisionIcon(decision) } { `${decisionDisplayName(decision)}` }
-        </Text></Fragment>
-      ]
-    }, {
-      parent: key * 2,
-      fullWidth: true,
-      cells: [{
-        title: <ExpandableContent actionsDisabled={ actionsDisabled } id={ id }
-          number_of_children={ number_of_children }
-          state={ state }
-          reason={ reason }/>
-      }]
-    }
-  ]), []);
-
+export const createRows = (data, actionsDisabled) => data.reduce((acc, request, key) => ([
+  ...acc, {
+    id: request.id,
+    isOpen: false,
+    state: request.state,
+    number_of_children: request.number_of_children,
+    cells: [
+      <Fragment key={ request.id }><Link to={ { pathname: routes.request.index, search: `?request=${request.id}` } }>{ request.id }</Link></Fragment>,
+      request.name,
+      request.requester_name,
+      timeAgo(request.created_at),
+      request.finished_at ? timeAgo(request.finished_at) : (request.notified_at ? timeAgo(request.notified_at) : timeAgo(request.created_at)),
+      request.state,
+      <Fragment key={ `decision-${request.id}` }><Text key={ `${request.decision}-$(request.id}` } style={ { marginBottom: 0 } }
+        className="data-table-detail content">
+        { decisionIcon(request.decision) } { `${decisionDisplayName(request.decision)}` }
+      </Text></Fragment>
+    ]
+  }, {
+    parent: key * 2,
+    fullWidth: true,
+    cells: [{
+      title: <ExpandableContent actionsDisabled={ actionsDisabled(request) } id={ request.id }
+        number_of_children={ request.number_of_children }
+        state={ request.state }
+        reason={ request.reason }/>
+    }]
+  }
+]), []);

--- a/src/smart-components/request/requests-list.js
+++ b/src/smart-components/request/requests-list.js
@@ -73,7 +73,7 @@ const requestsListState = (state, action) => {
   }
 };
 
-const RequestsList = ({ routes, persona, actionResolver }) => {
+const RequestsList = ({ routes, persona, actionResolver, actionsDisabled }) => {
   const { requests: { data, meta }, sortBy, filterValue } = useSelector(
     ({ requestReducer: { requests, sortBy, filterValue }}) => ({ requests, sortBy, filterValue }),
     shallowEqual
@@ -175,6 +175,7 @@ const RequestsList = ({ routes, persona, actionResolver }) => {
         fetchData={ updateRequests }
         routes={ routes }
         actionResolver={ actionResolver }
+        actionsDisabled={ actionsDisabled }
         titlePlural="requests"
         titleSingular="request"
         pagination={ meta }
@@ -276,7 +277,11 @@ const RequestsList = ({ routes, persona, actionResolver }) => {
 RequestsList.propTypes = {
   routes: PropTypes.func,
   actionResolver: PropTypes.func,
+  actionsDisabled: PropTypes.func,
   persona: PropTypes.string
+};
+RequestsList.default = {
+  actionsDisabled: () => true,
 };
 
 export default RequestsList;

--- a/src/smart-components/request/requests-list.js
+++ b/src/smart-components/request/requests-list.js
@@ -277,7 +277,7 @@ const RequestsList = ({ routes, persona, actionResolver, actionsDisabled }) => {
 RequestsList.propTypes = {
   routes: PropTypes.func,
   actionResolver: PropTypes.func,
-  actionsDisabled: PropTypes.func,
+  actionsDisabled: PropTypes.bool,
   persona: PropTypes.string
 };
 RequestsList.default = {

--- a/src/smart-components/request/requests-list.js
+++ b/src/smart-components/request/requests-list.js
@@ -277,7 +277,7 @@ const RequestsList = ({ routes, persona, actionResolver, actionsDisabled }) => {
 RequestsList.propTypes = {
   routes: PropTypes.func,
   actionResolver: PropTypes.func,
-  actionsDisabled: PropTypes.bool,
+  actionsDisabled: PropTypes.func,
   persona: PropTypes.string
 };
 RequestsList.default = {

--- a/src/smart-components/request/requests-list.js
+++ b/src/smart-components/request/requests-list.js
@@ -281,7 +281,7 @@ RequestsList.propTypes = {
   persona: PropTypes.string
 };
 RequestsList.default = {
-  actionsDisabled: () => true,
+  actionsDisabled: () => true
 };
 
 export default RequestsList;


### PR DESCRIPTION
Fixes https://projects.engineering.redhat.com/browse/SSP-1569

The buttons should be  available in the expanded content only in the Rquest Queue tab, not in All requests
