### PR TITLE
detail pane cleanup

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -9,10 +9,6 @@
   }
 }
 
-.detail-title {
-  margin-bottom: 16px;
-}
-
 .data-table-detail {
   &.heading {
     margin: 0 !important
@@ -23,9 +19,8 @@
 }
 
 .detail-pane {
-  background-color: white;
+  background-color: var(--pf-global--BackgroundColor--100);
   min-height: 100%;
-  padding: 20px;
   overflow: ellipsis;
   word-wrap: break-word
 }
@@ -39,7 +34,7 @@
 
 .destructive-color {
   &:not(:disabled) {
-    color: #FF0000 !important;
+    color: var(--pf-chart-color-red-100) !important;
   }
 }
 
@@ -81,10 +76,6 @@
       }
     }
   }
-}
-
-.global-primary-background {
-  background-color: #fff
 }
 
 .icon-danger-fill {

--- a/src/presentational-components/shared/loader-placeholders.js
+++ b/src/presentational-components/shared/loader-placeholders.js
@@ -76,7 +76,7 @@ export const RequestLoader = () => (
           </StackItem>
         </Stack>
       </GridItem>
-      <GridItem md={ 8 } lg={ 9 } className="detail-pane">
+      <GridItem md={ 8 } lg={ 9 } className="detail-pane pf-u-p-lg">
         <DataListLoader/>
       </GridItem>
     </Grid>

--- a/src/smart-components/request/request-detail/request-detail.js
+++ b/src/smart-components/request/request-detail/request-detail.js
@@ -62,7 +62,7 @@ const RequestDetail = () => {
           <GridItem md={ 4 } lg={ 3 } className="info-bar">
             <RequestInfoBar request={ selectedRequest } requestContent={ requestContent }/>
           </GridItem>
-          <GridItem md={ 8 } lg={ 9 } className="detail-pane">
+          <GridItem md={ 8 } lg={ 9 } className="detail-pane pf-u-p-lg">
             <RequestTranscript request={ selectedRequest } url={ location.url }/>
           </GridItem>
         </Fragment>

--- a/src/smart-components/request/request-detail/request-info-bar.js
+++ b/src/smart-components/request/request-detail/request-info-bar.js
@@ -18,7 +18,7 @@ const RequestInfoBar = ({ request, requestContent }) => (
           <Stack gutter="md">
             <StackItem key={ 'request-summary' }>
               <Title headingLevel="h5" size="lg">
-                    Summary
+                Summary
               </Title>
             </StackItem>
             <StackItem key={ 'request-product' }>

--- a/src/smart-components/request/request-detail/request-transcript.js
+++ b/src/smart-components/request/request-detail/request-transcript.js
@@ -5,7 +5,7 @@ import RequestList from './request-list';
 
 const RequestTranscript = ({ request }) => {
   return (<Fragment>
-    <Title size="sm" style={ { paddingLeft: '32px' } }> Request transcript </Title>
+    <Title headingLevel="h5" size="lg" className="pf-u-pl-lg pf-u-pb-lg">Request transcript</Title>
     <RequestList items={ request.requests && request.requests.length > 0 ? request.requests : [ request ] }/>
   </Fragment>);
 };


### PR DESCRIPTION
This PR adjusts the "Request transcript" header styling  as well as other refactoring.

Old
<img width="801" alt="Screen Shot 2020-06-10 at 4 48 36 PM" src="https://user-images.githubusercontent.com/1287144/84317130-4d351a00-ab3a-11ea-9878-c513ba7540dc.png">

New
<img width="778" alt="Screen Shot 2020-06-10 at 4 47 30 PM" src="https://user-images.githubusercontent.com/1287144/84317127-4c9c8380-ab3a-11ea-9d60-df97ada90bd5.png">

