### PR TITLE
remove toolbar styling override

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -66,9 +66,3 @@
   color: var(--pf-global--Color--100);
   font-weight: bold;
 }
-
-.ins__approval__primary_toolbar {
-  .pf-c-data-toolbar__content {
-    padding: 0;
-  }
-}


### PR DESCRIPTION
Removing the L-R padding override of PF styling better matches the mock


Before
<img width="897" alt="Screen Shot 2020-06-16 at 12 53 46 PM" src="https://user-images.githubusercontent.com/1287144/84806838-514ab700-afd4-11ea-8615-c6e9ca660fd6.png">


After
<img width="848" alt="Screen Shot 2020-06-16 at 12 56 22 PM" src="https://user-images.githubusercontent.com/1287144/84804552-f4013680-afd0-11ea-9a53-781da66e9035.png">

Mock up
<img width="442" alt="Screen Shot 2020-06-16 at 12 59 44 PM" src="https://user-images.githubusercontent.com/1287144/84804859-5a865480-afd1-11ea-8ca3-cd3e4ec11a45.png">

