### PR TITLE
Remove custom "table-fix" class

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -21,12 +21,6 @@
   }
 }
 
-.table-fix {
-  .pf-c-table__toggle {
-    padding-top: 0;
-  }
-}
-
 .disabled-link {
   pointer-events: none;
 }

--- a/src/presentational-components/shared/table-toolbar-view.js
+++ b/src/presentational-components/shared/table-toolbar-view.js
@@ -129,7 +129,7 @@ export const TableToolbarView = ({
             cells={ columns }
             onSelect={ isSelectable && setSelected }
             actionResolver={ actionResolver }
-            className="table-fix"
+            className="pf-u-pt-0"
             sortBy={ sortBy }
             onSort={ onSort }
           >


### PR DESCRIPTION
The PR replaces the custom "table-fix" class with a standard PF padding class.


Old
<img width="557" alt="Screen Shot 2020-06-24 at 5 29 41 PM" src="https://user-images.githubusercontent.com/1287144/85630022-ed159c00-b640-11ea-92be-5dc86b2a3029.png">

New
<img width="567" alt="Screen Shot 2020-06-24 at 5 30 28 PM" src="https://user-images.githubusercontent.com/1287144/85630024-ed159c00-b640-11ea-9c25-f47854e308a0.png">
