### PR TITLE
detail screen refactor

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -3,16 +3,16 @@
 
 .detail-pane {
   background-color: var(--pf-global--BackgroundColor--100);
-  min-height: 100%;
-  overflow: ellipsis;
-  word-wrap: break-word
 }
 
-.info-bar {
+.detail-pane, .info-bar {
   min-height: 100%;
-  padding: 0;
-  overflow: ellipsis;
-  word-wrap: break-word
+  @supports not (overflow-wrap: anywhere) {
+    word-break: break-all;
+  }
+  @supports (overflow-wrap: anywhere) {
+    overflow-wrap: anywhere;
+  }
 }
 
 .destructive-color {

--- a/src/smart-components/request/request-detail/request-detail.js
+++ b/src/smart-components/request/request-detail/request-detail.js
@@ -59,7 +59,7 @@ const RequestDetail = () => {
     else {
       return (
         <Fragment>
-          <GridItem md={ 4 } lg={ 3 } className="info-bar">
+          <GridItem md={ 4 } lg={ 3 } className="info-bar pf-u-p-0">
             <RequestInfoBar request={ selectedRequest } requestContent={ requestContent }/>
           </GridItem>
           <GridItem md={ 8 } lg={ 9 } className="detail-pane pf-u-p-lg">


### PR DESCRIPTION
Refactor of "info-bar" and "detail-pane" styling. Adds overflow-wrap fallback support for IE & Safari .

Before
![Screen Shot 2020-06-26 at 10 40 44 AM](https://user-images.githubusercontent.com/1287144/85869872-4c3af400-b79a-11ea-9e3c-fc5cde2473d5.png)

After
![Screen Shot 2020-06-26 at 10 42 32 AM](https://user-images.githubusercontent.com/1287144/85869874-4c3af400-b79a-11ea-9df0-b88b8efbf455.png)
