### PR TITLE
Add variant property to modals

### DIFF
--- a/src/smart-components/workflow/edit-workflow-groups-modal.js
+++ b/src/smart-components/workflow/edit-workflow-groups-modal.js
@@ -77,7 +77,7 @@ const EditWorkflowGroupsModal = ({
   return (
     <Modal
       title={ `Edit approval process's groups` }
-      width={ '40%' }
+      variant="small"
       isOpen
       onClose={ onCancel }>
       { state.isLoading ? <WorkflowInfoFormLoader/> : <FormRenderer

--- a/src/smart-components/workflow/edit-workflow-info-modal.js
+++ b/src/smart-components/workflow/edit-workflow-info-modal.js
@@ -98,7 +98,7 @@ const EditWorkflowInfoModal = ({
   return (
     <Modal
       title={ editType === 'sequence' ? 'Edit sequence' : 'Edit information' }
-      width={ '40%' }
+      variant="small"
       isOpen
       onClose={ onCancel }
     >

--- a/src/smart-components/workflow/remove-workflow-modal.js
+++ b/src/smart-components/workflow/remove-workflow-modal.js
@@ -63,7 +63,6 @@ const RemoveWorkflowModal = ({
         },
         { count: finalId ? 1 : ids.length })
       }
-      width={ '40%' }
       header={
         <Title size="2xl" headingLevel="h1">
           <ExclamationTriangleIcon size="sm" fill="#f0ab00" className="pf-u-mr-sm" />


### PR DESCRIPTION
This PR fixes an issue where all modals are extremely narrow in the mobile layout, by replacing width of 40% with the small size variant.

Jira: https://projects.engineering.redhat.com/browse/SSP-1625


Old
<img width="873" alt="Screen Shot 2020-07-09 at 1 20 35 PM" src="https://user-images.githubusercontent.com/1287144/87071410-2f65de00-c1e8-11ea-88aa-cdb12557b927.png">

New
<img width="882" alt="Screen Shot 2020-07-09 at 1 20 09 PM" src="https://user-images.githubusercontent.com/1287144/87071408-2ecd4780-c1e8-11ea-9aa7-8615241179a5.png">

