### PR TITLE
Fetch requester name in transcript query

### DIFF
--- a/src/helpers/request/request-helper.js
+++ b/src/helpers/request/request-helper.js
@@ -57,6 +57,7 @@ const requestTranscriptQuery = (parent_id) => `query {
     group_name
     number_of_finished_children
     state
+    requester_name
     actions {
       id
       operation


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/SSP-1703

- the value was missing in request detail summary card

Before

![image](https://user-images.githubusercontent.com/32869456/88277815-a2d81700-cce1-11ea-9558-e83744b4aa5c.png)

After

![image](https://user-images.githubusercontent.com/32869456/88277798-9c499f80-cce1-11ea-9789-79e54083fc5c.png)
