### PR TITLE
Bump FC to remove show more title prop warnings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1999,9 +1999,9 @@
       }
     },
     "@redhat-cloud-services/frontend-components": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components/-/frontend-components-2.3.5.tgz",
-      "integrity": "sha512-95eNhBA1G0QfwYk0k0ZSveX53CZR/Bw38OEHrMdsnuegZVoaiE99DSOf4Um/FMh0zRt6eRPV2fcEU6Fj1wyTuw==",
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components/-/frontend-components-2.3.6.tgz",
+      "integrity": "sha512-Go9PNp80Hfzcnlua+sWvL3ItVHNlx9KdiCZ+LRST+A1t0WUCZkn+WsbQ9zpTmdMcgNdN2lScnbbgk+xnWAbXZA==",
       "requires": {
         "@redhat-cloud-services/frontend-components-utilities": "*",
         "sanitize-html": "^1.25.0"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@patternfly/react-icons": "^4.5.0",
     "@patternfly/react-table": "^4.12.1",
     "@redhat-cloud-services/approval-client": "^1.0.64",
-    "@redhat-cloud-services/frontend-components": "^2.3.5",
+    "@redhat-cloud-services/frontend-components": "^2.3.6",
     "@redhat-cloud-services/frontend-components-notifications": "^2.1.1",
     "@redhat-cloud-services/frontend-components-utilities": "^2.1.0",
     "@redhat-cloud-services/rbac-client": "^1.0.64",


### PR DESCRIPTION
FC introduced a prop warning in one of the latest versions (please see https://github.com/RedHatInsights/frontend-components/pull/648 )

```jsx
react_devtools_backend.js:2273 Warning: Unknown event handler property `onShowMore`. It will be ignored.
    in input (created by TextInputBase)
    in TextInputBase (created by ForwardRef)
    in ForwardRef (created by Text)
    in Text (created by ConditionalFilter)
    in div (created by SplitItem)
    in SplitItem (created by ConditionalFilter)
    in div (created by Split)
    in Split (created by ConditionalFilter)
    in ConditionalFilter (created by PrimaryToolbar)
```

```jsx
react_devtools_backend.js:2273 Warning: React does not recognize the `showMoreTitle` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `showmoretitle` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
    in input (created by TextInputBase)
    in TextInputBase (created by ForwardRef)
    in ForwardRef (created by Text)
    in Text (created by ConditionalFilter)
    in div (created by SplitItem)
    in SplitItem (created by ConditionalFilter)
    in div (created by Split)
    in Split (created by ConditionalFilter)
    in ConditionalFilter (created by PrimaryToolbar)
```

Fixed in 2.3.6

@Hyperkid123 @lgalis 