### PR TITLE
Refactor remove workflow modal text

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -46,3 +46,7 @@
 .ins-c-primary-toolbar .ins-c-primary-toolbar__group-filter {
    margin-right: 7px;
  }
+
+.span-block {
+  display: block;
+}

--- a/src/messages/workflows.messages.js
+++ b/src/messages/workflows.messages.js
@@ -29,10 +29,6 @@ const worfklowMessages = defineMessages({
     id: 'worfklowMessages.approvalProcesses',
     defaultMessage: 'approval processes'
   },
-  fromProcessDependencies: {
-    id: 'worfklowMessages.fromProcessDependencies',
-    defaultMessage: '{space}from the following applications: {newline} {dependenciesList}'
-  },
   noApprovalProcesses: {
     id: 'worfklowMessages.noApprovalProcesses',
     defaultMessage: 'No approval processes'
@@ -55,7 +51,11 @@ const worfklowMessages = defineMessages({
   },
   removeProcessDescription: {
     id: 'workflowMessages.removeProcessDescription',
-    defaultMessage: '{name} will be removed{dependenciesMessageValue}'
+    defaultMessage: '{name} will be removed.'
+  },
+  removeProcessDescriptionWithDeps: {
+    id: 'workflowMessages.removeProcessDescriptionWithDeps',
+    defaultMessage: '{name} will be removed from the following applications: {dependenciesList}'
   },
   editProcessTitle: {
     id: 'workflowMessages.editProcessTitle',

--- a/src/smart-components/workflow/remove-workflow-modal.js
+++ b/src/smart-components/workflow/remove-workflow-modal.js
@@ -67,6 +67,20 @@ const RemoveWorkflowModal = ({
     .reduce((acc, item) => [ ...acc, `${APP_DISPLAY_NAME[item] || item}` ], []);
   };
 
+  const name = (
+    <b key="remove-key">
+      {
+        finalId
+          ? fetchedWorkflow && fetchedWorkflow.name || workflow && workflow.name
+          : (<React.Fragment>
+            { ids.length } { intl.formatMessage(worfklowMessages.approvalProcesses) }
+          </React.Fragment>)
+      }
+    </b>
+  );
+
+  const isLoading = finalId && !workflow && !fetchedWorkflow;
+
   return (
     <Modal
       isOpen
@@ -96,26 +110,16 @@ const RemoveWorkflowModal = ({
       <TextContent>
         <Text component={ TextVariants.p }>
           {
-            (finalId && !workflow && !fetchedWorkflow)
+            isLoading
               ? <FormItemLoader/>
-              : intl.formatMessage(worfklowMessages.removeProcessDescription, {
-                name: <b key="remove-key">{
-                  finalId
-                    ? fetchedWorkflow && fetchedWorkflow.name || workflow && workflow.name
-                    : (<React.Fragment>
-                      { ids.length } { intl.formatMessage(worfklowMessages.approvalProcesses) }
-                    </React.Fragment>)
-                }</b>,
-                dependenciesMessageValue:
-                      isEmpty(dependenciesMessage()) ? '.' : intl.formatMessage(worfklowMessages.fromProcessDependencies, {
-                        space: <React.Fragment>&nbsp;</React.Fragment>,
-                        newline: <React.Fragment><br/><br/></React.Fragment>,
-                        dependenciesList: <React.Fragment>{ dependenciesMessage().map(item => <React.Fragment key={ item }>
-                          <li>{ item }</li>
-                        </React.Fragment>) }</React.Fragment>
-                      })
-              }
-              )
+              : isEmpty(dependenciesMessage())
+                ? intl.formatMessage(worfklowMessages.removeProcessDescription, { name })
+                : intl.formatMessage(worfklowMessages.removeProcessDescriptionWithDeps, {
+                  name,
+                  dependenciesList: <span key="span" className="pf-u-mt-lg span-block">
+                    { dependenciesMessage().map(item => <li key={ item }>{ item }</li>) }
+                  </span>
+                })
           }
         </Text>
       </TextContent>

--- a/src/test/smart-components/workflow/remove-workflow-modal.test.js
+++ b/src/test/smart-components/workflow/remove-workflow-modal.test.js
@@ -93,7 +93,7 @@ describe('<RemoveWorkflowModal />', () => {
     expect(wrapper.find(Modal)).toHaveLength(1);
     expect(wrapper.find(Title).first().text()).toEqual('Delete approval process?');
     expect(wrapper.find(Text).first().text())
-    .toEqual('WfName will be removed from the following applications:  Automation Services CatalogTopological inventory');
+    .toEqual('WfName will be removed from the following applications: Automation Services CatalogTopological inventory');
   });
 
   it('should render approval process modal - single - not in table', async () => {


### PR DESCRIPTION
- cleaner code
- splitting the message into two will help translators to understand the context better

Also cleans the one warning in the test log (elements in `formatMessage` do have to have a key)

@lgalis @Hyperkid123 