### PR TITLE
Fix tables vertical align

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -57,3 +57,7 @@
   white-space: nowrap;
   overflow: hidden;
 }
+
+.pf-c-table.vertical-align-inherit tbody > tr > * {
+  vertical-align: inherit !important;
+}

--- a/src/presentational-components/shared/table-toolbar-view.js
+++ b/src/presentational-components/shared/table-toolbar-view.js
@@ -89,7 +89,7 @@ export const TableToolbarView = ({
             rows={ rows }
             cells={ columns }
             actionResolver={ actionResolver }
-            className="pf-u-pt-0"
+            className="pf-u-pt-0 vertical-align-inherit"
             sortBy={ sortBy }
             onSort={ onSort }
           >


### PR DESCRIPTION
The table cell content was aligned to the top instead of the center.

### Before
![screenshot-ci foo redhat com_1337-2020 08 18-09_12_30](https://user-images.githubusercontent.com/22619452/90483148-90ac9580-e134-11ea-9a10-49e337beb6eb.png)

### After
![screenshot-ci foo redhat com_1337-2020 08 18-09_23_55](https://user-images.githubusercontent.com/22619452/90483164-93a78600-e134-11ea-88ea-a3a09161e029.png)
