### PR TITLE
Refresh request list after approve/deny actions

### DIFF
--- a/src/smart-components/request/action-modal.js
+++ b/src/smart-components/request/action-modal.js
@@ -22,7 +22,8 @@ const ActionModal = ({
   actionType,
   createRequestAction,
   closeUrl,
-  postMethod
+  postMethod,
+  postMethohdParameter
 }) => {
   const intl = useIntl();
   const { push } = useHistory();
@@ -39,7 +40,7 @@ const ActionModal = ({
         id,
         { operation: operationType[actionType], ...data },
         intl
-      ).then(() => postMethod()).then(() => push(closeUrl))
+      ).then(() => postMethod(postMethohdParameter)).then(() => push(closeUrl))
       : createRequestAction(
         actionName,
         id,
@@ -77,6 +78,7 @@ ActionModal.propTypes = {
   createRequestAction: PropTypes.func.isRequired,
   postMethod: PropTypes.func,
   actionType: PropTypes.string,
+  postMethohdParameter: PropTypes.string,
   closeUrl: PropTypes.oneOfType([ PropTypes.string, PropTypes.shape({ patname: PropTypes.string, search: PropTypes.string }) ])
 };
 

--- a/src/smart-components/request/action-modal.js
+++ b/src/smart-components/request/action-modal.js
@@ -22,8 +22,7 @@ const ActionModal = ({
   actionType,
   createRequestAction,
   closeUrl,
-  postMethod,
-  postMethodParameter
+  postMethod
 }) => {
   const intl = useIntl();
   const { push } = useHistory();
@@ -40,7 +39,7 @@ const ActionModal = ({
         id,
         { operation: operationType[actionType], ...data },
         intl
-      ).then(() => postMethod(postMethodParameter)).then(() => push(closeUrl))
+      ).then(() => postMethod()).then(() => push(closeUrl))
       : createRequestAction(
         actionName,
         id,
@@ -78,8 +77,6 @@ ActionModal.propTypes = {
   createRequestAction: PropTypes.func.isRequired,
   postMethod: PropTypes.func,
   actionType: PropTypes.string,
-  postMethodParameter: PropTypes.oneOfType(PropTypes.string,
-    PropTypes.shape({ count: PropTypes.string, limit: PropTypes.string, offset: PropTypes.string })),
   closeUrl: PropTypes.oneOfType([ PropTypes.string, PropTypes.shape({ patname: PropTypes.string, search: PropTypes.string }) ])
 };
 

--- a/src/smart-components/request/action-modal.js
+++ b/src/smart-components/request/action-modal.js
@@ -23,7 +23,7 @@ const ActionModal = ({
   createRequestAction,
   closeUrl,
   postMethod,
-  postMethohdParameter
+  postMethodParameter
 }) => {
   const intl = useIntl();
   const { push } = useHistory();
@@ -40,7 +40,7 @@ const ActionModal = ({
         id,
         { operation: operationType[actionType], ...data },
         intl
-      ).then(() => postMethod(postMethohdParameter)).then(() => push(closeUrl))
+      ).then(() => postMethod(postMethodParameter)).then(() => push(closeUrl))
       : createRequestAction(
         actionName,
         id,
@@ -78,7 +78,8 @@ ActionModal.propTypes = {
   createRequestAction: PropTypes.func.isRequired,
   postMethod: PropTypes.func,
   actionType: PropTypes.string,
-  postMethohdParameter: PropTypes.string,
+  postMethodParameter: PropTypes.oneOfType(PropTypes.string,
+    PropTypes.shape({ count: PropTypes.string, limit: PropTypes.string, offset: PropTypes.string })),
   closeUrl: PropTypes.oneOfType([ PropTypes.string, PropTypes.shape({ patname: PropTypes.string, search: PropTypes.string }) ])
 };
 

--- a/src/smart-components/request/requests-list.js
+++ b/src/smart-components/request/requests-list.js
@@ -27,6 +27,9 @@ import routes from '../../constants/routes';
 import tableToolbarMessages from '../../messages/table-toolbar.messages';
 import requestsMessages from '../../messages/requests.messages';
 import commonMessages from '../../messages/common.message';
+import { Route } from 'react-router-dom';
+import routesLinks from '../../constants/routes';
+import ActionModal from './action-modal';
 
 const columns = (intl) => [{
   title: intl.formatMessage(requestsMessages.requestsIdColumn),
@@ -77,7 +80,7 @@ const requestsListState = (state, action) => {
   }
 };
 
-const RequestsList = ({ routes, persona, indexpath, actionResolver }) => {
+const RequestsList = ({ persona, indexpath, actionResolver }) => {
   const { requests: { data, meta }, sortBy, filterValue } = useSelector(
     ({ requestReducer: { requests, sortBy, filterValue }}) => ({ requests, sortBy, filterValue }),
     shallowEqual
@@ -105,6 +108,21 @@ const RequestsList = ({ routes, persona, indexpath, actionResolver }) => {
     .then(() => stateDispatch({ type: 'setFetching', payload: false }))
     .catch(() => stateDispatch({ type: 'setFetching', payload: false }));
   };
+
+  const routes = () => <Fragment>
+    <Route exact path={ routesLinks.requests.addComment } render={ props => <ActionModal { ...props }
+      actionType={ 'Add Comment' }
+      postMethod={ updateRequests }
+      postMethodParameter={ meta }/> }/>
+    <Route exact path={ routesLinks.requests.approve } render={ props => <ActionModal { ...props } actionType={ 'Approve' }
+      postMethod={ updateRequests }
+      postMethodParameter={ meta }
+    /> } />
+    <Route exact path={ routesLinks.requests.deny } render={ props => <ActionModal { ...props } actionType={ 'Deny' }
+      postMethod={ updateRequests }
+      postMethodParameter={ meta }
+    /> } />
+  </Fragment>;
 
   const resetList = () => {
     dispatch(resetRequestList());

--- a/src/smart-components/request/requests-list.js
+++ b/src/smart-components/request/requests-list.js
@@ -112,15 +112,13 @@ const RequestsList = ({ persona, indexpath, actionResolver }) => {
   const routes = () => <Fragment>
     <Route exact path={ routesLinks.requests.addComment } render={ props => <ActionModal { ...props }
       actionType={ 'Add Comment' }
-      postMethod={ updateRequests }
-      postMethodParameter={ meta }/> }/>
+      postMethod={ () => updateRequests(meta) }
+    /> }/>
     <Route exact path={ routesLinks.requests.approve } render={ props => <ActionModal { ...props } actionType={ 'Approve' }
-      postMethod={ updateRequests }
-      postMethodParameter={ meta }
+      postMethod={ () => updateRequests(meta) }
     /> } />
     <Route exact path={ routesLinks.requests.deny } render={ props => <ActionModal { ...props } actionType={ 'Deny' }
-      postMethod={ updateRequests }
-      postMethodParameter={ meta }
+      postMethod={ () => updateRequests(meta) }
     /> } />
   </Fragment>;
 

--- a/src/smart-components/request/requests.js
+++ b/src/smart-components/request/requests.js
@@ -1,7 +1,4 @@
-import React, { Fragment, useContext } from 'react';
-import { Route } from 'react-router-dom';
-import { fetchRequests } from '../../redux/actions/request-actions';
-import ActionModal from './action-modal';
+import React, { useContext } from 'react';
 import {
   APPROVAL_APPROVER_PERSONA, useIsApprovalAdmin,
   useIsApprovalApprover,
@@ -18,16 +15,6 @@ const Requests = () => {
   const { userRoles: userRoles } = useContext(UserContext);
   const isApprovalAdmin = useIsApprovalAdmin(userRoles);
   const isApprovalApprover = useIsApprovalApprover(userRoles);
-
-  const routes = () => <Fragment>
-    <Route exact path={ routesLinks.requests.addComment } render={ props => <ActionModal { ...props }
-      actionType={ 'Add Comment' }
-      postMethod={ fetchRequests } /> }/>
-    <Route exact path={ routesLinks.requests.approve } render={ props => <ActionModal { ...props } actionType={ 'Approve' }
-      postMethod={ fetchRequests }/> } />
-    <Route exact path={ routesLinks.requests.deny } render={ props => <ActionModal { ...props } actionType={ 'Deny' }
-      postMethod={ fetchRequests }/> } />
-  </Fragment>;
 
   const actionsDisabled = (requestData) => requestData &&
     requestData.state ?
@@ -48,7 +35,6 @@ const Requests = () => {
   return !isApprovalApprover ?
     <EmptyRequestList/>
     : <RequestsList
-      routes={ routes }
       persona={ APPROVAL_APPROVER_PERSONA }
       actionResolver={ actionResolver }
     />;

--- a/src/test/smart-components/request/requests.test.js
+++ b/src/test/smart-components/request/requests.test.js
@@ -482,6 +482,7 @@ describe('<Requests />', () => {
       wrapper.update();
 
       expect(wrapper.find(ActionModal).props().actionType).toEqual('Add Comment');
+      expect(wrapper.find(ActionModal).props().postMethod).toBeDefined();
       expect(wrapper.find(MemoryRouter).instance().history.location.pathname).toEqual(routes.requests.addComment);
       expect(wrapper.find(MemoryRouter).instance().history.location.search).toEqual('?request=703');
     });
@@ -508,6 +509,7 @@ describe('<Requests />', () => {
       wrapper.update();
 
       expect(wrapper.find(ActionModal).props().actionType).toEqual('Approve');
+      expect(wrapper.find(ActionModal).props().postMethod).toBeDefined();
       expect(wrapper.find(MemoryRouter).instance().history.location.pathname).toEqual(routes.requests.approve);
       expect(wrapper.find(MemoryRouter).instance().history.location.search).toEqual('?request=703');
     });
@@ -534,6 +536,7 @@ describe('<Requests />', () => {
       wrapper.update();
 
       expect(wrapper.find(ActionModal).props().actionType).toEqual('Deny');
+      expect(wrapper.find(ActionModal).props().postMethod).toBeDefined();
       expect(wrapper.find(MemoryRouter).instance().history.location.pathname).toEqual(routes.requests.deny);
       expect(wrapper.find(MemoryRouter).instance().history.location.search).toEqual('?request=703');
     });


### PR DESCRIPTION
On the My Request list, when a request was approved or denied, the list was not refreshed, so the new state was not reflected.

https://projects.engineering.redhat.com/browse/SSP-1802