### PR TITLE
Allow adding comments on all requests, based on capabilities

### DIFF
--- a/src/smart-components/request/request-actions.js
+++ b/src/smart-components/request/request-actions.js
@@ -19,7 +19,7 @@ const RequestActions = ({
 
   const { id, state } = request;
   const approveDenyAllowed = isRequestStateActive(state) && canApproveDeny;
-  const commentAllowed = isRequestStateActive(state) && canComment;
+  const commentAllowed = canComment;
 
   return (
     <div style={ { display: 'flex' } }>

--- a/src/test/smart-components/request/request-detail/__snapshots__/request.test.js.snap
+++ b/src/test/smart-components/request/request-detail/__snapshots__/request.test.js.snap
@@ -275,7 +275,49 @@ exports[`<Request /> should render correctly 1`] = `
                           "display": "flex",
                         }
                       }
-                    />
+                    >
+                      <Link
+                        id="comment-111"
+                        to={
+                          Object {
+                            "pathname": "/request/comment",
+                            "search": "request=111",
+                          }
+                        }
+                      >
+                        <LinkAnchor
+                          href="/request/comment?request=111"
+                          id="comment-111"
+                          navigate={[Function]}
+                        >
+                          <a
+                            href="/request/comment?request=111"
+                            id="comment-111"
+                            onClick={[Function]}
+                          >
+                            <Button
+                              aria-label="Comment"
+                              ouiaId="comment-request-111"
+                              variant="secondary"
+                            >
+                              <button
+                                aria-disabled={false}
+                                aria-label="Comment"
+                                className="pf-c-button pf-m-secondary"
+                                data-ouia-component-id="comment-request-111"
+                                data-ouia-component-type="PF4/Button"
+                                data-ouia-safe={true}
+                                disabled={false}
+                                role={null}
+                                type="button"
+                              >
+                                Comment
+                              </button>
+                            </Button>
+                          </a>
+                        </LinkAnchor>
+                      </Link>
+                    </div>
                   </RequestActions>
                 </div>
               </DataListCell>


### PR DESCRIPTION
Allow adding comments to approval requests based only on the user capabilities, regardless of the request status. This is only on the individual request detail page. The request list page will display the status for approved or denied requests.


Fixes https://issues.redhat.com/browse/SSP-2061

Before:
![Screenshot from 2021-01-13 16-47-34](https://user-images.githubusercontent.com/12769982/104518089-27d32780-55c5-11eb-9414-34ebdb539229.png)


After:
![Screenshot from 2021-01-13 16-20-52](https://user-images.githubusercontent.com/12769982/104518215-636df180-55c5-11eb-98c6-e8f28cb2cab6.png)
