### PR TITLE
Fix empty filtered requests

### DIFF
--- a/src/presentational-components/shared/table-toolbar-view.js
+++ b/src/presentational-components/shared/table-toolbar-view.js
@@ -74,13 +74,13 @@ export const TableToolbarView = ({
       activeFiltersConfig={ activeFiltersConfig }
     />
   );
-
+  console.log('Debug - activeFiltersConfig, activeFiltersConfig.filters.length', activeFiltersConfig, activeFiltersConfig.filters.length);
   return (
     <Section type="content" page-type={ `tab-${titlePlural}` } id={ `tab-${titlePlural}` }>
       { routes() }
-      { (rows.length !== 0 || filterValue || isLoading) && renderToolbar(isLoading) }
+      { (rows.length !== 0 || activeFiltersConfig.filters.length > 0) && renderToolbar(isLoading) }
       { isLoading && <DataListLoader/> }
-      { !isLoading && rows.length === 0 ? (
+      { (rows.length === 0 && !isLoading) ? (
         renderEmptyState()
       ) :
         <Fragment>

--- a/src/presentational-components/shared/table-toolbar-view.js
+++ b/src/presentational-components/shared/table-toolbar-view.js
@@ -74,12 +74,13 @@ export const TableToolbarView = ({
       activeFiltersConfig={ activeFiltersConfig }
     />
   );
+  console.log('Debug - activeFiltersConfig, activeFiltersConfig.filters.length', activeFiltersConfig, activeFiltersConfig.filters.length);
   return (
     <Section type="content" page-type={ `tab-${titlePlural}` } id={ `tab-${titlePlural}` }>
       { routes() }
-      { (rows.length !== 0 || activeFiltersConfig.filters.length > 0) && renderToolbar(isLoading) }
+      { (rows.length !== 0 || activeFiltersConfig?.filters?.length > 0) && renderToolbar(isLoading) }
       { isLoading && <DataListLoader/> }
-      { (rows.length === 0 && !isLoading) ? (
+      { !isLoading && rows.length === 0 ? (
         renderEmptyState()
       ) :
         <Fragment>

--- a/src/presentational-components/shared/table-toolbar-view.js
+++ b/src/presentational-components/shared/table-toolbar-view.js
@@ -74,7 +74,6 @@ export const TableToolbarView = ({
       activeFiltersConfig={ activeFiltersConfig }
     />
   );
-  console.log('Debug - activeFiltersConfig, activeFiltersConfig.filters.length', activeFiltersConfig, activeFiltersConfig.filters.length);
   return (
     <Section type="content" page-type={ `tab-${titlePlural}` } id={ `tab-${titlePlural}` }>
       { routes() }

--- a/src/smart-components/request/requests-list.js
+++ b/src/smart-components/request/requests-list.js
@@ -126,6 +126,8 @@ const RequestsList = ({ persona, indexpath, actionResolver }) => {
   </Fragment>;
 
   const resetList = () => {
+    stateDispatch({ type: 'clearFilters' });
+    dispatch(clearFilterValueRequests());
     dispatch(resetRequestList());
   };
 

--- a/src/test/presentional-components/table-toolbar-view.test.js
+++ b/src/test/presentional-components/table-toolbar-view.test.js
@@ -6,6 +6,7 @@ import { IntlProvider } from 'react-intl';
 
 import { TableToolbarView as TableToolbarViewOriginal } from '../../presentational-components/shared/table-toolbar-view';
 import { DataListLoader } from '../../presentational-components/shared/loader-placeholders';
+import { TextInput, Chip } from '@patternfly/react-core';
 
 describe('<TableToolbarView />', () => {
   let initialProps;
@@ -24,7 +25,8 @@ describe('<TableToolbarView />', () => {
         limit: 50,
         offset: 0,
         count: 51
-      }
+      },
+      activeFiltersConfig: { filters: []}
     };
   });
 
@@ -68,6 +70,25 @@ describe('<TableToolbarView />', () => {
     expect(wrapper.find(Table)).toHaveLength(0);
     expect(wrapper.find(TableHeader)).toHaveLength(0);
     expect(wrapper.find(TableBody)).toHaveLength(0);
+    done();
+  });
+
+  it('should display the filter box state', async done => {
+    let wrapper;
+    const renderEmptyState = jest.fn();
+    await act(async() => {
+      wrapper = mount(<TableToolbarView { ...initialProps } activeFiltersConfig={ { filters: [{ category: 'Name',
+        chips: [{ name: 'val', key: 'val' }],
+        key: 'name' }]} }
+      isLoading={ false } renderEmptyState={ renderEmptyState } />);
+    });
+
+    act(() => {
+      wrapper.update();
+    });
+    expect(wrapper.find(TextInput)).toHaveLength(1);
+    expect(wrapper.find(Chip)).toHaveLength(1);
+    expect(wrapper.find(Table)).toHaveLength(0);
     done();
   });
 


### PR DESCRIPTION
Fix the toolbar to still display the search filter when the search return no results.
Clear the search filter when switching between the 2 requests tabs

Fixes https://issues.redhat.com/browse/SSP-2039
