### PR TITLE
Revert "Bump @redhat-cloud-services/frontend-components from 3.6.0 to 3.6.2"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@patternfly/react-icons": "^4.43.15",
         "@patternfly/react-table": "^4.61.15",
         "@redhat-cloud-services/approval-client": "^1.0.94",
-        "@redhat-cloud-services/frontend-components": "^3.6.2",
+        "@redhat-cloud-services/frontend-components": "^3.6.0",
         "@redhat-cloud-services/frontend-components-config": "^4.5.12",
         "@redhat-cloud-services/frontend-components-notifications": "^3.2.5",
         "@redhat-cloud-services/frontend-components-utilities": "^3.2.3",
@@ -2271,9 +2271,9 @@
       }
     },
     "node_modules/@redhat-cloud-services/frontend-components": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components/-/frontend-components-3.6.2.tgz",
-      "integrity": "sha512-eTsVxWK1I9oqNg2RH8MpirWRN8KLuNOg35QLQ4rT1iHVmU+qFzty5FmOWG9TbFX3jC7IOi9DDj8X50KbpKs3sA==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components/-/frontend-components-3.6.0.tgz",
+      "integrity": "sha512-rf57Qobz7Ws2Kpdiwz73go3ZpEKWoUZnFxUYcoUiQNNWGfZhTy1WTbmHFngN1n9M3rPPk3ttwgf/iNiyaxnukA==",
       "dependencies": {
         "@redhat-cloud-services/frontend-components-utilities": ">=3.0.0",
         "@scalprum/core": "^0.1.1",
@@ -19469,9 +19469,9 @@
       }
     },
     "@redhat-cloud-services/frontend-components": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components/-/frontend-components-3.6.2.tgz",
-      "integrity": "sha512-eTsVxWK1I9oqNg2RH8MpirWRN8KLuNOg35QLQ4rT1iHVmU+qFzty5FmOWG9TbFX3jC7IOi9DDj8X50KbpKs3sA==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components/-/frontend-components-3.6.0.tgz",
+      "integrity": "sha512-rf57Qobz7Ws2Kpdiwz73go3ZpEKWoUZnFxUYcoUiQNNWGfZhTy1WTbmHFngN1n9M3rPPk3ttwgf/iNiyaxnukA==",
       "requires": {
         "@redhat-cloud-services/frontend-components-utilities": ">=3.0.0",
         "@scalprum/core": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@patternfly/react-icons": "^4.43.15",
     "@patternfly/react-table": "^4.61.15",
     "@redhat-cloud-services/approval-client": "^1.0.94",
-    "@redhat-cloud-services/frontend-components": "^3.6.2",
+    "@redhat-cloud-services/frontend-components": "^3.6.0",
     "@redhat-cloud-services/frontend-components-config": "^4.5.12",
     "@redhat-cloud-services/frontend-components-notifications": "^3.2.5",
     "@redhat-cloud-services/frontend-components-utilities": "^3.2.3",


### PR DESCRIPTION
 Reverts RedHatInsights/approval-ui#627  - it is causing layout issues with the filter box